### PR TITLE
Conceal Original HTTP Referrer

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,0 +1,14 @@
+osTicket v1.7
+=============
+
+New Features
+============
+Version 1.7 includes several new features
+
+API
+---
+Interface with osTicket via HTTP requests. Starting with version 1.7,
+tickets are createable by submitting an HTTP POST request to either
+
+    /api/tickets.xml
+    /api/tickets.json

--- a/include/class.format.php
+++ b/include/class.format.php
@@ -117,10 +117,12 @@ class Format {
     function clickableurls($text) {
 
         //Not perfect but it works - please help improve it. 
-        $text=preg_replace('/(((f|ht){1}tp(s?):\/\/)[-a-zA-Z0-9@:%_\+.~#?&;\/\/=]+)/','<a href="\\1" target="_blank">\\1</a>', $text);
+        $text=preg_replace('/(((f|ht){1}tp(s?):\/\/)[-a-zA-Z0-9@:%_\+.~#?&;\/\/=]+)/',
+            '<a href="l.php?url=\\1" target="_blank">\\1</a>', $text);
         $text=preg_replace("/(^|[ \\n\\r\\t])(www\.([a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+)(\/[^\/ \\n\\r]*)*)/",
-                '\\1<a href="http://\\2" target="_blank">\\2</a>', $text);
-        $text=preg_replace("/(^|[ \\n\\r\\t])([_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,4})/",'\\1<a href="mailto:\\2" target="_blank">\\2</a>', $text);
+            '\\1<a href="l.php?url=http://\\2" target="_blank">\\2</a>', $text);
+        $text=preg_replace("/(^|[ \\n\\r\\t])([_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,4})/",
+            '\\1<a href="l.php?url=mailto:\\2" target="_blank">\\2</a>', $text);
 
         return $text;
     }

--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -139,6 +139,22 @@ class Misc {
         return $output;
     }
 
-   
+    function siteBaseUrl() {
+        # Detects Alias-ing
+        $paths = explode('/', $_SERVER['REQUEST_URI']);
+        # Drop the last item -- it will be the php page we're on
+        array_pop($paths);
+        $leading = array();
+        while (count($paths)) {
+            if (in_array($paths[0], array('scp','client')))
+                break;
+            $leading[] = array_shift($paths);
+        }
+        if (count($leading) > 1)
+            return implode('/', $leading);
+        else
+            return '';
+    }
+
 }
 ?>

--- a/l.php
+++ b/l.php
@@ -1,0 +1,29 @@
+<?php
+/*********************************************************************
+    l.php
+
+    Link redirection
+
+    Jared Hancock <jared@osticket.com>
+    Copyright (c)  2006-2012 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+require 'secure.inc.php';
+
+global $_GET;
+$url = $_GET['url'];
+if (!$url) exit();
+?>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="refresh" content="0;<?php echo $url; ?>"/>
+</head>
+<body/>
+</html>

--- a/scp/l.php
+++ b/scp/l.php
@@ -1,0 +1,29 @@
+<?php
+/*********************************************************************
+    l.php
+
+    Link redirection
+
+    Jared Hancock <jared@osticket.com>
+    Copyright (c)  2006-2012 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+require_once 'staff.inc.php';
+
+global $_GET;
+$url = $_GET['url'];
+if (!$url) exit();
+?>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="refresh" content="0;<?php echo $url; ?>"/>
+</head>
+<body/>
+</html>


### PR DESCRIPTION
Change href definitions for embedded links in the ticket thread so that the click will be bounced through a script. This will hide the original referrer URL where the link originated.
