### PR TITLE
Add simple syntax check to test suite

### DIFF
--- a/setup/test/lint.php
+++ b/setup/test/lint.php
@@ -14,16 +14,53 @@ function get_osticket_root_path() {
 
 $root = get_osticket_root_path();
 
+# Check PHP syntax across all php files
+function glob_recursive($pattern, $flags = 0) {
+    $files = glob($pattern, $flags);
+    foreach (glob(dirname($pattern).'/*', GLOB_ONLYDIR|GLOB_NOSORT) 
+            as $dir) {
+        $files = array_merge($files, 
+            glob_recursive($dir.'/'.basename($pattern), $flags));
+    }
+    return $files;
+}
+echo "PHP Syntax Errors: ";
+ob_start();
+$scripts=glob_recursive("$root/*/*.php");
+$exit=0;
+$syntax_errors="";
+foreach ($scripts as $s) {
+    system("php -l $s", $exit);
+    $line = ob_get_contents();
+    ob_clean();
+    if ($exit !== 0)
+        $syntax_errors .= $line;
+}
+ob_end_clean();
+
+if (strlen($syntax_errors)) {
+    $syntax_errors=str_replace("$root/", '', $syntax_errors);
+    echo "FAIL\n";
+    echo "-------------------------------------------------------\n";
+    echo "$syntax_errors";
+    exit();
+} else {
+    echo "\n";
+}
+
 # Run phplint across all php files
+echo "Access to unitialized variables: ";
 ob_start();
 # XXX: This won't run well on Windoze
-system("$root/setup/test/lib/phplint.tcl $root/**/*.php 2>&1");
+system("$root/setup/test/lib/phplint.tcl ".implode(" ", $scripts));
 $lint_errors = ob_get_clean();
-$lint_errors=str_replace("$root/", '', $lint_errors);
 
 if (strlen($lint_errors)) {
-    echo "FAIL: Access to unitialized variables\n";
+    $lint_errors=str_replace("$root/", '', $lint_errors);
+    echo "FAIL\n";
     echo "-------------------------------------------------------\n";
     echo "$lint_errors";
+} else {
+    echo "\n";
 }
 ?>


### PR DESCRIPTION
And make globbing platform independent, which also fixes an issue where not
all PHP files were scanned by the phplint tool for uninitialized variables
