### PR TITLE
Creating Team Error - Column 'isenabled' specified twice

### DIFF
--- a/include/class.team.php
+++ b/include/class.team.php
@@ -200,7 +200,6 @@ class Team {
 
         $sql='SET updated=NOW(),isenabled='.db_input($vars['isenabled']).
              ',name='.db_input($vars['name']).
-             ',isenabled='.db_input($vars['isenabled']).
              ',noalerts='.db_input(isset($vars['noalerts'])?$vars['noalerts']:0).
              ',notes='.db_input($vars['notes']);
 


### PR DESCRIPTION
When you create a team you get this error: "Unable to create the team. Internal error". The below error is emailed to you.

[INSERT INTO ost_team SET updated=NOW(),isenabled=1,name='Support Level 2',isenabled=1,noalerts='0',notes='',created=NOW()]

Column 'isenabled' specified twice
