### PR TITLE
Shows all closed tickets

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -402,7 +402,7 @@ $negorder=$order=='DESC'?'ASC':'DESC'; //Negate the sorting..
             <?php
             } //end of while.
         else: //not tickets found!! set fetch error.
-            $ferror='Query returned 0 results.';  
+            $ferror='There are no tickets here. (Leave a little early today).';  
         endif; ?>
     </tbody>
     <tfoot>
@@ -414,7 +414,9 @@ $negorder=$order=='DESC'?'ASC':'DESC'; //Negate the sorting..
             <a href="#" onclick="return reset_all(document.forms['tickets'])">None</a>&nbsp;&nbsp;
             <a href="#" onclick="return toogle_all(document.forms['tickets'],true)">Toggle</a>&nbsp;&nbsp;
             <?php }else{
+                echo '<i>';
                 echo $ferror?Format::htmlchars($ferror):'Query returned 0 results.';
+                echo '</i>';
             } ?>
         </td>
      </tr>

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -378,14 +378,6 @@ endif;
 /*... Quick stats ...*/
 $stats= $thisstaff->getTicketsStats();
 
-// Switch queues on the fly! depending on stats
-if(!$stats['open'] && $_REQUEST['a']!='search' && (!$_REQUEST['status'] || $_REQUEST['status']=='open')) {
-    if(!$cfg->showAnsweredTickets() && $stats['answered'])
-        $_REQUEST['status']= 'answered';
-    else
-        $_REQUEST['status']= 'closed';
-}
-
 //Navigation
 $nav->setTabActive('tickets');
 if($cfg->showAnsweredTickets()) {
@@ -396,7 +388,7 @@ if($cfg->showAnsweredTickets()) {
                         (!$_REQUEST['status'] || $_REQUEST['status']=='open'));
 } else {
 
-    if(!$stats || $stats['open']) {
+    if($stats) {
         $nav->addSubMenu(array('desc'=>'Open ('.$stats['open'].')',
                                'title'=>'Open Tickets',
                                'href'=>'tickets.php',


### PR DESCRIPTION
Hi,

When all the open tickets are closed then it shows all the closed tickets.

It must show "query returned 0 results" instead of closed tickets as it creates confusion a lot of time. This was a drawback in the 1.6 version. Kindly rectify this in the 1.7 version release. 
