### PR TITLE
new canned response not working

### DIFF
--- a/include/staff/cannedreply.inc.php
+++ b/include/staff/cannedreply.inc.php
@@ -77,7 +77,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
                 if($canned && ($files=$canned->getAttachments())) {
                     echo '<div id="canned_attachments"><span class="faded">Uncheck to delete the attachment on submit</span><br>';
                     foreach($files as $file) {
-                        $hash=$file['hash'].md5($file['id'].session_id());
+                        $hash=$file['hash'].md5($file['id'].session_id().$file['hash']);
                         echo sprintf('<label><input type="checkbox" name="files[]" id="f%d" value="%d" checked="checked">
                                       <a href="file.php?h=%s">%s</a>&nbsp;&nbsp;</label>&nbsp;',
                                       $file['id'], $file['id'], $hash, $file['name']);

--- a/scp/canned.php
+++ b/scp/canned.php
@@ -54,7 +54,7 @@ if($_POST && $thisstaff->canManageCannedResponses()) {
             }
             break;
         case 'create':
-            if(($id=Canned::create($_POST, $_FILES['attachments'], $errors))) {
+            if(($id=Canned::create($_POST, $errors))) {
                 $msg='Canned response added successfully';
                 $_REQUEST['a']=null;
                 //Upload attachments


### PR DESCRIPTION
When trying to add a new canned response this is comes up with the fallowing error:

Unable to add canned response. Correct error(s) below and try again.

Status is Active
Tile: test
Canned Response: testing123
Nothing is attachment and internal notes. 
