### PR TITLE
Deprecated: Assigning the return value of new by reference is deprecated in /.../osTicket/include/pear/Mail/smtp.php on line 322

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -38,7 +38,12 @@
     //ini_set('session.cookie_path','/osticket/');
 
     #Error reporting...Good idea to ENABLE error reporting to a file. i.e display_errors should be set to false
-    error_reporting(E_ALL ^ E_NOTICE); //Respect whatever is set in php.ini (sysadmin knows better??)
+    $error_reporting = E_ALL & ~E_NOTICE;
+    if (defined('E_STRICT')) # 5.4.0
+        $error_reporting &= ~E_STRICT;
+    if (defined('E_DEPRECATED')) # 5.3.0
+        $error_reporting &= ~(E_DEPRECATED | E_USER_DEPRECATED);
+    error_reporting($error_reporting); //Respect whatever is set in php.ini (sysadmin knows better??)
     #Don't display errors
     ini_set('display_errors',1);
     ini_set('display_startup_errors',1);


### PR DESCRIPTION
When sending a test mail from a system using SMTP, this depreciation warning appears. The mail is being sent correctly.

Using PHP 5.3.3-7+squeeze3 with Suhosin-Patch and osTicket (v1.7-DPR3).
