### PR TITLE
Fix PHP crash when system is offline due to pending upgrade

### DIFF
--- a/offline.php
+++ b/offline.php
@@ -14,7 +14,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 require_once('client.inc.php');
-if($cfg && !$cfg->isHelpDeskOffline()) { 
+if(is_object($ost) && $ost->isSystemOnline()) {
     @header('Location: index.php'); //Redirect if the system is online.
     include('index.php');
     exit;


### PR DESCRIPTION
The `index.php` script references the `offline.php` script for the client interface when the system has a pending upgrade, which does not detect the system status correctly and includes `index.php`, which includes `offline.php`, ...
