### PR TITLE
Ticket assign to team

### DIFF
--- a/include/class.team.php
+++ b/include/class.team.php
@@ -80,6 +80,13 @@ class Team {
         return $this->members;
     }
 
+    function hasMember($staff) {
+        return db_count(
+             'SELECT COUNT(*) FROM '.TEAM_MEMBER_TABLE
+            .' WHERE team_id='.db_input($this->getId())
+            .'   AND staff_id='.db_input($staff->getId())) !== 0;
+    }
+
     function getLeadId(){
         return $this->ht['lead_id'];
     }

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -20,7 +20,10 @@ $lock  = $ticket->getLock();  //Ticket lock obj
 $id    = $ticket->getId();    //Ticket ID.
 
 //Useful warnings and errors the user might want to know!
-if($ticket->isAssigned() && $staff->getId()!=$thisstaff->getId())
+if($ticket->isAssigned() && (
+            ($staff && $staff->getId()!=$thisstaff->getId())
+         || ($team && !$team->hasMember($thisstaff))
+        ))
     $warn.='&nbsp;&nbsp;<span class="Icon assignedTicket">Ticket is assigned to '.implode('/', $ticket->getAssignees()).'</span>';
 if(!$errors['err'] && ($lock && $lock->getStaffId()!=$thisstaff->getId()))
     $errors['err']='This ticket is currently locked by '.$lock->getStaffName();


### PR DESCRIPTION
osTicket (v1.7-DPR4)
PHP: 5.4.0-3

If you assign a ticket to a team, you can not view this ticket

You will get an Fatal error:
Fatal error: Call to a member function getId() on a non-object in /include/staff/ticket-view.inc.php on line 23
