### PR TITLE
Use email priority when available

### DIFF
--- a/api/pipe.php
+++ b/api/pipe.php
@@ -87,7 +87,7 @@ $var['emailId']=$emailId?$emailId:$cfg->getDefaultEmailId();
 $var['subject']=$subj?$subj:'[No Subject]';
 $var['message']=utf8_encode(Format::stripEmptyLines($body));
 $var['header']=$parser->getHeader();
-$var['pri']=$cfg->useEmailPriority()?$parser->getPriority():0;
+$var['priorityId']=$cfg->useEmailPriority()?$parser->getPriority():0;
 
 $ticket=null;
 if(preg_match ("[[#][0-9]{1,10}]",$var['subject'],$regs)) {

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -283,7 +283,7 @@ class MailFetcher {
         $var['mid']=$mailinfo['mid'];
 
         if($cfg->useEmailPriority())
-            $var['pri']=$this->getPriority($mid);
+            $var['priorityId']=$this->getPriority($mid);
        
         $ticket=null;
         $newticket=true;


### PR DESCRIPTION
There is an error in the name of the variable that is used by us to the creation of tickets via email pipe.php the line this way:

 $ var ['pri'] = $ cfg-> useEmailPriority ()? $ parser-> getPriority (): 0;

 and should be as follows:

 $ var ['priorityId'] = $ cfg-> useEmailPriority ()? $ parser-> getPriority (): 0;

 generating the ticket does not believe that the priority of the email.

 Excuse my bad English.

 Greetings from Venezuela.
