### PR TITLE
Fix removed no-break spaces from emails

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -249,6 +249,8 @@ class MailFetcher {
                 $body=str_replace(array("<br>", "<br />", "<BR>", "<BR />"), "\n", $body);
                 $body=Format::html($body); //Balance html tags before stripping.
                 $body=Format::striptags($body); //Strip tags??
+                //removing no-break space, cause leads to failures in some cases
+		$body = str_replace('&nbsp;', ' ',$body);
             }
         }
         return $body;


### PR DESCRIPTION
In a few cases the html nbsp sign crashes the inserting of mail body into the database.
