### PR TITLE
Property handle Unicode and HTML entities

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -88,7 +88,12 @@ class Format {
     }
 
     function htmlchars($var) {
-        return is_array($var)?array_map(array('Format','htmlchars'),$var):htmlspecialchars($var,ENT_QUOTES);
+        $flags = ENT_COMPAT | ENT_QUOTES;
+        if (phpversion() >= '5.4.0')
+            $flags |= ENT_HTML401;
+        return is_array($var)
+            ? array_map(array('Format','htmlchars'),$var)
+            : htmlentities($var, $flags, 'UTF-8');
     }
 
     function input($var) {
@@ -114,7 +119,13 @@ class Format {
     }
 
     function striptags($var) {
-        return is_array($var)?array_map(array('Format','striptags'),$var):strip_tags(html_entity_decode($var)); //strip all tags ...no mercy!
+        $flags = ENT_COMPAT;
+        if (phpversion() >= '5.4.0')
+            $flags |= ENT_HTML401;
+        return is_array($var)
+            ? array_map(array('Format','striptags'),$var)
+              //strip all tags ...no mercy!
+            : strip_tags(html_entity_decode($var, $flags, 'UTF-8'));
     }
 
     //make urls clickable. Mainly for display 


### PR DESCRIPTION
I'm not sure I really like this change, but let's start the discussion. This code properly converts **all** HTML entities to their UTF-8 encoded counterparts. This should be storable in the database without any trouble. When data is displayed, all the UTF-8 characters that have an HTML entity counterpart are converted (as opposed to just the basic ones).

This will _hopefully_ fix entities like `&nbsp;`, which could potentially not have been converted properly -- for PHP < 5.4.0, it would be converted to ASCII char 160, which could be interpreted a number of different ways including breaking database statements. Furthermore, it should correctly reproduce the `&nbsp;` when the content is to be sent back to the client again. Lastly, it should hopefully be future-proof and support other entities such as `&mdash;` and so on.

For PHP >= 5.4.0, this code will only have the effect of switching to the `htmlentities` function. `UTF-8` is the default encoding scheme for PHP >= 5.4.0. From that perspective, this code will help make osTicket more consistent with future versions of PHP
