### PR TITLE
Fix Teams not populated in the staff edit form

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -53,7 +53,7 @@ class Staff {
         
         $this->ht=db_fetch_array($res);
         $this->id  = $this->ht['staff_id'];
-        $this->teams = $this->ht['teams'] = array();
+        $this->ht['teams'] = $this->GetTeams();
         $this->group = $this->dept = null;
         $this->departments = $this->stats = array();
 


### PR DESCRIPTION
Fix teams fields not being populated in the staff edit form
