### PR TITLE
Fix filters applied on web created tickets

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -236,9 +236,9 @@ class Filter {
         );
         $match = false;
         # Respect configured filter email-id
-        if ($email['emailId'] && $this->getEmailId()
-                && $this->getEmailId() != $email['emailId'])
+        if ($this->getEmailId() && $this->getEmailId() != $email['emailId'])
             return false;
+
         foreach ($this->getRules() as $rule) {
             list($func, $pos, $neg) = $how[$rule['h']];
             # TODO: convert $what and $rule['v'] to mb_strtoupper and do


### PR DESCRIPTION
If we create a TT from the web (no 'emailId'), email filters with an emailId defined, are still applied to the ticket. This is obviously not wanted.

This fix prevents this bug to happen.
