### PR TITLE
Fix "File Upload Error" in SCP 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ osTicket is supported by several magical open source projects including:
   * [PEAR/Net_Socket](http://pear.php.net/package/Net_Socket)
   * [PEAR/Serivces_JSON](http://pear.php.net/package/Services_JSON)
   * [phplint](http://antirez.com/page/phplint.html) 
+


### PR DESCRIPTION
Since the multi-files upload features (I guess),  the uploaded file array can hold an empty array that triggers the error "File Upload Error" in SCP.

This commit fixes this by making sure each files array is not empty (it must have a tmp_name)
