### PR TITLE
Attachements can be downloaded AND displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ osTicket is supported by several magical open source projects including:
   * [PEAR/Net_Socket](http://pear.php.net/package/Net_Socket)
   * [PEAR/Serivces_JSON](http://pear.php.net/package/Services_JSON)
   * [phplint](http://antirez.com/page/phplint.html) 
+


### PR DESCRIPTION
When clicking on an attachement (from the Ticket view), it defaults to display the file in a new window (letting the browser display the file or not, depending on the mime-type). Files can still be (force) downloaded by clicking on the small icon.
IMO this is really more convenient, when most of the attachements are images or pdf.

(While this commit doesn't require my last "mime types" pull request, it should be more secure to include it.)

BTW I've currently harcoded a small style in the links to allow it to merge smoothly, in my current develop branch, without breaking my CSS branch. When you'd approve or deny my CSS pull request, I would move this to the exernals stylesheets, and make it more beautifull.
