### PR TITLE
Saving recipient from email

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -235,11 +235,13 @@ class MailFetcher {
             return null;
 
         $sender=$headerinfo->from[0];
+        $recipient=$headerinfo->to[0];
         //Just what we need...
-        $header=array('name'  =>@$sender->personal,
-                      'email' =>(strtolower($sender->mailbox).'@'.$sender->host),
-                      'subject'=>@$headerinfo->subject,
-                      'mid'    =>$headerinfo->message_id
+        $header=array('name'    =>@$sender->personal,
+                      'email'   =>(strtolower($sender->mailbox).'@'.$sender->host),
+                      'recipient_email'=>(strtolower($recipient->mailbox).'@'.$recipient->host),
+                      'subject' =>@$headerinfo->subject,
+                      'mid'     =>$headerinfo->message_id
                       );
 
         return $header;
@@ -386,6 +388,7 @@ class MailFetcher {
 
         $var['name']=$this->mime_decode($mailinfo['name']);
         $var['email']=$mailinfo['email'];
+        $var['recipient_email']=$mailinfo['recipient_email'];
         $var['subject']=$mailinfo['subject']?$this->mime_decode($mailinfo['subject']):'[No Subject]';
         $var['message']=Format::stripEmptyLines($this->getBody($mid));
         $var['header']=$this->getHeader($mid);

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1931,6 +1931,8 @@ class Ticket{
         # function
         if (isset($vars['autorespond'])) $autorespond=$vars['autorespond'];
 
+        $vars['recipient_email'] = (isset($vars['recipient_email'])) ? $vars['recipient_email'] : '' ;
+
         //Any error above is fatal.
         if($errors)  return 0;
         
@@ -1971,6 +1973,7 @@ class Ticket{
             .' ,topic_id='.db_input($topicId)
             .' ,priority_id='.db_input($priorityId)
             .' ,email='.db_input($vars['email'])
+            .' ,recipient_email='.db_input($vars['recipient_email'])
             .' ,name='.db_input(Format::striptags($vars['name']))
             .' ,subject='.db_input(Format::striptags($vars['subject']))
             .' ,phone="'.db_input($vars['phone'],false).'"'

--- a/include/upgrader/sql/recipient.patch.sql
+++ b/include/upgrader/sql/recipient.patch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `%TABLE_PREFIX%ticket` ADD  `recipient_email` VARCHAR( 120 ) NOT NULL AFTER  `email`


### PR DESCRIPTION
I added a feature for saving also the recipient address of EMails to the Database.
There are a few benefits for us (may also for others)

We use customer@support EMail Addresses, so we can track now all tickets of a customer, it doesent matter from which employee  the mail was send.

We create the most Tickets EMail based, meaning we move the mail from private inbox to our osTicket inbox. With this change we doesent loose the originial recipient from the mail

I will add the frontend functions for it later (view, filter)
