### PR TITLE
Sticky Sort

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -193,15 +193,27 @@ $orderWays=array('DESC'=>'DESC','ASC'=>'ASC');
 $order_by=$order=null;
 if($_REQUEST['sort'] && $sortOptions[$_REQUEST['sort']])
     $order_by =$sortOptions[$_REQUEST['sort']];
+elseif(!strcasecmp($status, 'open') && !$showanswered && $sortOptions[$_SESSION['tickets']['sort']]) {
+    $_REQUEST['sort'] = $_SESSION['tickets']['sort'];
+    $order_by = $sortOptions[$_SESSION['tickets']['sort']];
+    $order = $_SESSION['tickets']['order'];
+}
 
 if($_REQUEST['order'] && $orderWays[strtoupper($_REQUEST['order'])])
     $order=$orderWays[strtoupper($_REQUEST['order'])];
+
+//Save sort order for sticky sorting.
+if(!strcasecmp($status, 'open') && $_REQUEST['sort']) {
+    $_SESSION['tickets']['sort'] = $_REQUEST['sort'];
+    $_SESSION['tickets']['order'] = $_REQUEST['order'];
+}
 
 if(!$order_by && $showanswered) {
     $order_by='ticket.lastresponse, ticket.created'; //No priority sorting for answered tickets.
 }elseif(!$order_by && !strcasecmp($status,'closed')){
     $order_by='ticket.closed, ticket.created'; //No priority sorting for closed tickets.
 }
+
 $order_by =$order_by?$order_by:'priority_urgency, effective_date, ticket.created';
 $order=$order?$order:'ASC';
 


### PR DESCRIPTION
Save sort preference for the duration of the session - only for open tickets.

By default osTicket sorts open tickets based on urgency score - composed on ticket priority and create date. Staff can resort the tickets by clicking on the column headers... this pull request "saves" the last sort preference on page reload.
