### PR TITLE
open_basedir restriction while adding staff

### DIFF
--- a/include/PasswordHash.php
+++ b/include/PasswordHash.php
@@ -48,7 +48,7 @@ class PasswordHash {
 	function get_random_bytes($count)
 	{
 		$output = '';
-		if (is_readable('/dev/urandom') &&
+		if (@is_readable('/dev/urandom') &&
 		    ($fh = @fopen('/dev/urandom', 'rb'))) {
 			$output = fread($fh, $count);
 			fclose($fh);

--- a/include/pear/Auth/SASL/DigestMD5.php
+++ b/include/pear/Auth/SASL/DigestMD5.php
@@ -178,10 +178,10 @@ class Auth_SASL_DigestMD5 extends Auth_SASL_Common
     */
     function _getCnonce()
     {
-        if (file_exists('/dev/urandom') && $fd = @fopen('/dev/urandom', 'r')) {
+        if (@file_exists('/dev/urandom') && $fd = @fopen('/dev/urandom', 'r')) {
             return base64_encode(fread($fd, 32));
 
-        } elseif (file_exists('/dev/random') && $fd = @fopen('/dev/random', 'r')) {
+        } elseif (@file_exists('/dev/random') && $fd = @fopen('/dev/random', 'r')) {
             return base64_encode(fread($fd, 32));
 
         } else {


### PR DESCRIPTION
I've just installed a copy of the release candiate.

While I was adding a new staff member and got the result "added successfully" I had the following error,

<pre>
Warning: is_readable() [function.is-readable]: open_basedir restriction in effect. File(/dev/urandom) is not within the allowed path(s): (/home:/tmp:/usr) in .../helpdesk/include/PasswordHash.php on line 51
</pre>


Any other information needed just let me know.
