### PR TITLE
Little (not final) bandaid for 'umlaut' problems

### DIFF
--- a/include/mysql.php
+++ b/include/mysql.php
@@ -30,8 +30,9 @@
         if($db) db_select_database($db);
 
         //set desired encoding just in case mysql charset is not UTF-8 - Thanks to FreshMedia
-        @mysql_query('SET NAMES "UTF8"');
+        @mysql_query('SET NAMES "utf8"');
         @mysql_query('SET COLLATION_CONNECTION=utf8_general_ci');
+        @mysql_query('SET CHARACTER SET "utf8"');
 
         @db_set_variable('sql_mode', '');
 


### PR DESCRIPTION
There a currently again big problems with german "umlaute", ä ü ö, the subject ist cuted at the frist umlaute. With this pre workarround (mysql character set utf8) its a bit better, the umlautes stored as ? in the Database. This is better then a missing subject.  I currently dont have i final solution.
