### PR TITLE
added admin login (/scp) link to front page

### DIFF
--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -33,7 +33,7 @@ header("Content-Type: text/html; charset=UTF-8\r\n");
                 <a href="<?php echo ROOT_PATH; ?>logout.php">Log Out</a>
              <?php
              }elseif($nav){ ?>
-                 Guest User - <a href="<?php echo ROOT_PATH; ?>login.php">Log In</a>
+                 Guest User - <a href="<?php echo ROOT_PATH; ?>login.php">Log In</a> Admin user - <a href="<?php echo ROOT_PATH;?>scp">Log In</a>
               <?php
              } ?>
             </p>


### PR DESCRIPTION
added admin login (/scp) link to front page beside guest login
There needs to be a link to log into the admin interface.
There's no way in hell everyone's going to remember /scp after being away from the system for a while. 
If not here, then somewhere else
