### PR TITLE
Client Login issues - issue #317

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -185,7 +185,7 @@ class Client {
                 $_SESSION['_client']['token'] = $user->getSessionToken();
                 $_SESSION['TZ_OFFSET'] = $cfg->getTZoffset();
                 $_SESSION['TZ_DST'] = $cfg->observeDaylightSaving();
-                
+                $user->refreshSession(); //set the hash.
                 //Log login info...
                 $msg=sprintf('%s/%s logged in [%s]', $ticket->getEmail(), $ticket->getExtId(), $_SERVER['REMOTE_ADDR']);
                 $ost->logDebug('User login', $msg);
@@ -193,10 +193,8 @@ class Client {
                 //Regenerate session ID.
                 $sid=session_id(); //Current session id.
                 session_regenerate_id(TRUE); //get new ID.
-                if(($session=$ost->getSession()) && is_object($session) && $sid)
+                if(($session=$ost->getSession()) && is_object($session) && $sid!=session_id())
                     $session->destroy($sid);
-
-                session_write_close();
 
                 return $user;
 

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -594,10 +594,8 @@ class Staff {
             $sid=session_id(); //Current id
             session_regenerate_id(TRUE);
             //Destroy old session ID - needed for PHP version < 5.1.0 TODO: remove when we move to php 5.3 as min. requirement.
-            if(($session=$ost->getSession()) && is_object($session) && $sid)
+            if(($session=$ost->getSession()) && is_object($session) && $sid!=session_id())
                 $session->destroy($sid);
-
-            session_write_close();
         
             return $user;
         }


### PR DESCRIPTION
Addresses issue #317.

*Remove session_write_close() - already registered as shutdown function in osTSession class.
*Make sure we don't destroy current/active session.
