### PR TITLE
Feature/locks revisited

### DIFF
--- a/include/class.lock.php
+++ b/include/class.lock.php
@@ -88,7 +88,7 @@ class TicketLock {
     function renew($lockTime=0) {
 
         if(!$lockTime || !is_numeric($lockTime)) //XXX: test to  make it works.
-            $lockTime = '(TIME_TO_SEC(TIMEDIFF(created,expire))/60)';
+            $lockTime = '(TIME_TO_SEC(TIMEDIFF(expire,created))/60)';
             
 
         $sql='UPDATE '.TICKET_LOCK_TABLE

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -366,6 +366,7 @@ if(!$cfg->showNotesInline()) { ?>
         <?php csrf_token(); ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="msgId" value="<?php echo $msgId; ?>">
+        <input type="hidden" name="locktime" value="<?php echo $cfg->getLockTime(); ?>">
         <input type="hidden" name="a" value="reply">
         <span class="error"></span>
         <table border="0" cellspacing="0" cellpadding="3">

--- a/scp/js/ticket.js
+++ b/scp/js/ticket.js
@@ -93,13 +93,18 @@ var autoLock = {
 
     Init: function(config) {
 
-        //make sure we are on ticket view page!
-        void(autoLock.form=document.forms['reply']);
-        if(!autoLock.form || !autoLock.form.id.value) {
-                return;
+        //make sure we are on ticket view page & locking is enabled!
+        var fObj=$('form#reply');
+        if(!fObj 
+                || !$(':input[name=id]',fObj).length 
+                || !$(':input[name=locktime]',fObj).length
+                || $(':input[name=locktime]',fObj).val()==0) {
+            return;
         }
 
-        void(autoLock.tid=parseInt(autoLock.form.id.value));
+        void(autoLock.tid=parseInt($(':input[name=id]',fObj).val()));
+        void(autoLock.lockTime=parseInt($(':input[name=locktime]',fObj).val()));
+
         autoLock.lockId=0;
         autoLock.timerId=0;
         autoLock.lasteventTime=0;
@@ -108,9 +113,6 @@ var autoLock = {
         autoLock.renewTime=0;
         autoLock.renewFreq=0; //renewal frequency in seconds...based on returned lock time.
         autoLock.time=0;
-        if(config && config.ticket_lock_time)
-            autoLock.timeTime=config.ticket_lock_time
-
         autoLock.lockAttempts=0; //Consecutive lock attempt errors
         autoLock.maxattempts=2; //Maximum failed lock attempts before giving up.
         autoLock.warn=true;


### PR DESCRIPTION
Addresses a couple of bugs on ticket locking mechanism.
- JS warning when locking is disabled
- Lock renew actually expired the lock
- Auto-detect if locking is enabled - & avoid unnecessary form/document monitoring
