### PR TITLE
Better support for international charsets

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -206,14 +206,22 @@ class MailFetcher {
         return utf8_encode($text);
     }
     
-    //Generic decoder - mirrors imap_utf8
+    // The function returns a text in utf-8 charset always
+    //
     function mime_decode($text) {
         
         $str = '';
         $parts = imap_mime_header_decode($text);
-        foreach ($parts as $part)
-            $str.= $part->text;
+        foreach ($parts as $part) {
+            if ($part->charset == 'utf-8') {
+                $str.= $part->text;
+            }
+        }
         
+        if (function_exists('iconv_mime_decode')) {
+            return $str?$str:iconv_mime_decode($text, 2, 'utf-8');
+        }
+
         return $str?$str:imap_utf8($text);
     }
 


### PR DESCRIPTION
Better support for international charsets.

The original code does not correctly convert mime lines like this one:
string(47) "=?windows-1251?B?0e3u4uD/IP8uIMPk5SDv7uzu+fw/?="

It results in an empty subject of a new ticket submitted via email.
