### PR TITLE
﻿Added support to In-Reply-To and References headers for sent and received ticket email replies.

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -241,9 +241,17 @@ class MailFetcher {
         $header=array('name'  =>@$sender->personal,
                       'email' =>(strtolower($sender->mailbox).'@'.$sender->host),
                       'subject'=>@$headerinfo->subject,
-                      'mid'    =>$headerinfo->message_id
+                      'mid'    =>$headerinfo->message_id,
+                      'inReplyTo'    =>$headerinfo->in_reply_to,
+                      'references'    =>$headerinfo->references
                       );
-
+							 
+        // TODO: Handle Microsoft specific Thread-Topic and Thread-Index headers.
+        //if(!($rawheaderinfo=imap_fetchheader($this->mbox, $mid))) {
+        //  ... do something ...
+        //  return $header;
+		//}
+        
         return $header;
     }
 
@@ -410,6 +418,8 @@ class MailFetcher {
         $var['emailId']=$emailId?$emailId:$ost->getConfig()->getDefaultEmailId(); //ok to default?
         $var['name']=$var['name']?$var['name']:$var['email']; //No name? use email
         $var['mid']=$mailinfo['mid'];
+        $var['inReplyTo']=$mailinfo['inReplyTo'];
+        $var['references']=$mailinfo['references'];
 
         if(!$var['message']) //An email with just attachments can have empty body.
             $var['message'] = '(EMPTY)';
@@ -419,8 +429,17 @@ class MailFetcher {
        
         $ticket=null;
         $newticket=true;
-        //Check the subject line for possible ID.
-        if($var['subject'] && preg_match ("[[#][0-9]{1,10}]", $var['subject'], $regs)) {
+        
+        //Check the "In-Reply-To" mail header to retrieve the original message
+        if ($var['inReplyTo'] && ($tid = Ticket::getIdByMessageId($var['inReplyTo'], $var['email']))) {
+            $ticket=new Ticket($tid);
+        
+        // If none found, check the "references" header
+        } elseif ($var['references'] && ($tid = Ticket::getIdByMessageId($var['references'], $var['email']))) {
+            $ticket=new Ticket($tid);
+        
+        // As last resort, check the subject line for possible ID.
+        } elseif (!$ticket && $var['subject'] && preg_match ("[[#][0-9]{1,10}]", $var['subject'], $regs)) {
             $tid=trim(preg_replace("/[^0-9]/", "", $regs[0]));
             //Allow mismatched emails?? For now NO.
             if(!($ticket=Ticket::lookupByExtId($tid)) || strcasecmp($ticket->getEmail(), $var['email']))

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1582,7 +1582,13 @@ class Ticket {
             //Set attachments if emailing.
             $attachments =($cfg->emailAttachments() && $attachments)?$this->getAttachments($respId,'R'):array();
             //TODO: setup  5 param (options... e.g mid trackable on replies)
-            $email->send($this->getEmail(), $msg['subj'], $msg['body'], $attachments);
+            
+            $options = array(
+                        'msgid' => $respId,
+                        'ticket_id' => $this->getId()
+                        );
+            
+            $email->send($this->getEmail(), $msg['subj'], $msg['body'], $attachments, $options);
         }
 
         return $respId;
@@ -1934,6 +1940,25 @@ class Ticket {
             list($id)=db_fetch_row($res);
 
         return $id;
+    }
+    
+    function getLastEmailMessageId($tid) {
+        if(!$tid)
+            return 0;
+
+        $sql='SELECT email_mid '
+             .' FROM '.TICKET_THREAD_TABLE.' msg '
+             .' INNER JOIN '.TICKET_EMAIL_INFO_TABLE.' emsg ON (msg.id = emsg.message_id) '
+             .' WHERE msg.ticket_id='.db_input($tid)
+             ."   AND msg.thread_type = 'M'"
+             .' ORDER BY msg.created DESC LIMIT 1';
+             
+        $mid=0;
+        
+        if(($res=db_query($sql)) && db_num_rows($res))
+            list($mid)=db_fetch_row($res);
+
+        return $mid;
     }
 
     function getOpenTicketsByEmail($email){


### PR DESCRIPTION
Actual changes:
- For every "ticket reply alert" sent to an user:
  - It is saved a record inside the  "ticket_email_info" table with the messageId, linking it to the originating support ticket reply
  - In-Reply-To and Refecerences headers are added to the sent mail, both set to the messageId of the latest email received from the user (if available), in order to help user email client to properly thread the ticket discussion.
- For every incoming email, In-Reply-To header, Refecerences header and the sender email are used to lookup the existing ticket. If found, it is used as ticket where to append the reply, otherwise the standard subject ticket id lookup is performed.

That's all. It seems to work nicely, and allows to omit the ticket ID from the mail subject of support replies (as the subject alteration break gmail email threading).

I tested it with IMAP access, so I don't know if it works correctly with POP3.

Some things to review:
- I don't know if it is correct to use the "References" header for the lookup, because it seems that it can have multiple message ids inside it. Maybe it is to split-up in order to lookup each id one at time.
- Actually, I converted the email headers sent to the user to the text saved inside the "email info" table with a print_f function. I'm pretty sure that it needs to be improved to match the format of headers saved for incoming email :) 
