### PR TITLE
Canned responses show up in menu when disabled

### DIFF
--- a/include/class.canned.php
+++ b/include/class.canned.php
@@ -217,11 +217,13 @@ class Canned {
 
     function getCannedResponses($deptId=0, $explicit=false) {
 
-        $sql='SELECT canned_id, title FROM '.CANNED_TABLE;
+        $sql='SELECT canned_id, title FROM '.CANNED_TABLE
+           .' WHERE isenabled';
         if($deptId){
-            $sql.=' WHERE dept_id='.db_input($deptId);
+            $sql.=' AND (dept_id='.db_input($deptId);
             if(!$explicit)
                 $sql.=' OR dept_id=0';
+            $sql.=')';
         }
         $sql.=' ORDER BY title';
 


### PR DESCRIPTION
Disabled canned responses still show up in the canned responses menu even if they are disabled. They are clickable; the only difference is the response doesn't get added to the email. The disabled responses should be either greyed out or (my personal preference) just not show up in the menu at all.
