### PR TITLE
Typo in `class.api.php`

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -386,7 +386,7 @@ class ApiJsonDataParser extends JsonDataParser {
                         # for the database. Otherwise, assume utf-8
                         list($param,$charset) = explode('=', $extra);
                         if ($param == 'charset' && $charset)
-                            $contents = Formart::utf8encode($contents, $charset);
+                            $contents = Format::utf8encode($contents, $charset);
                     }
                 }
                 unset($value);


### PR DESCRIPTION
`Formart` on line 389 should be `Format`
