### PR TITLE
Install may fail on Windows platforms

### DIFF
--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -113,10 +113,14 @@ class Installer extends SetupWizard {
         $debug = true; //XXX:Change it to true to show SQL errors.
 
         //Last minute checks.
-        if(!file_exists($schemaFile))
+        if(!file_exists($schemaFile) || !($fp = fopen($schemaFile, 'rb')))
             $this->errors['err']='Internal Error - please make sure your download is the latest (#1)';
-        elseif(!($signature=trim(file_get_contents("$schemaFile.md5"))) || strcasecmp($signature, md5_file($schemaFile)))
-            $this->errors['err']='Unknown or invalid schema signature ('.$signature.' .. '.md5_file($schemaFile).')';
+        elseif(
+                !($signature=trim(file_get_contents("$schemaFile.md5")))
+                || !($hash=md5(fread($fp, filesize($schemaFile))))
+                || strcasecmp($signature, $hash))
+            $this->errors['err']='Unknown or invalid schema signature ('
+                .$signature.' .. '.$hash.')';
         elseif(!file_exists($this->getConfigFile()) || !($configFile=file_get_contents($this->getConfigFile())))
             $this->errors['err']='Unable to read config file. Permission denied! (#2)';
         elseif(!($fp = @fopen($this->getConfigFile(),'r+')))


### PR DESCRIPTION
From an osTicket user,

Unknown or invalid schema signature (d959a00e55c75e0c903b9e37324fd25d .. 9e85d0c8f8532e3b0be38e99aba07aa1)

**To reproduce**

On a *nix box, open the osTicket-mysql.sql in ViM, and do `se ff=dos`, save and quit, then `md5sum` the file. The hash will be `9e85d0c8f8532e3b0be38e99aba07aa1`
