### PR TITLE
Fix HTTP assumptions in the installer

### DIFF
--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -144,7 +144,7 @@ class Installer extends SetupWizard {
             $sql='INSERT INTO '.PREFIX.'staff SET created=NOW() '
                 .", isactive=1, isadmin=1, group_id=$group_id_1, dept_id=$dept_id_1"
                 .", timezone_id=$eastern_timezone, max_page_size=25"
-                .', email='.db_input($_POST['admin_email'])
+                .', email='.db_input($vars['admin_email'])
                 .', firstname='.db_input($vars['fname'])
                 .', lastname='.db_input($vars['lname'])
                 .', username='.db_input($vars['username'])

--- a/setup/setup.inc.php
+++ b/setup/setup.inc.php
@@ -51,10 +51,10 @@ define('SETUPINC',true);
 define('URL',rtrim('http'.(($_SERVER['HTTPS']=='on')?'s':'').'://'.$_SERVER['HTTP_HOST'].dirname($_SERVER['PHP_SELF']),'setup'));
 
 #define paths
-define('INC_DIR','./inc/'); //local include dir!
+define('INC_DIR',dirname(__file__).'/inc/'); //local include dir!
 if(!defined('INCLUDE_DIR')):
-define('ROOT_PATH','../');
-define('ROOT_DIR','../');
+define('ROOT_PATH',dirname(__file__).'/../');
+define('ROOT_DIR',dirname(__file__).'/../');
 define('INCLUDE_DIR',ROOT_DIR.'include/');
 define('PEAR_DIR',INCLUDE_DIR.'pear/');
 ini_set('include_path', './'.PATH_SEPARATOR.INC_DIR.PATH_SEPARATOR.INCLUDE_DIR.PATH_SEPARATOR.PEAR_DIR);


### PR DESCRIPTION
The installer assumes that the CWD of the running PHP process is setup/,
which isn't necessarily true (if run from a cli module, for instance).
