### PR TITLE
Update class.osticket.php

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -337,10 +337,10 @@ class osTicket {
     }
 
     function get_path_info() {
-        if(isset($_SERVER['PATH_INFO']))
+        if($_SERVER['PATH_INFO'] != NULL)
             return $_SERVER['PATH_INFO'];
 
-        if(isset($_SERVER['ORIG_PATH_INFO']))
+        if($_SERVER['ORIG_PATH_INFO'] != NULL)
             return $_SERVER['ORIG_PATH_INFO'];
 
         //TODO: conruct possible path info.


### PR DESCRIPTION
IMPORTANT!!!!

On some configurations - like php running as fast cgi module - both statements returns true -         

isset($_SERVER['PATH_INFO'])
isset($_SERVER['ORIG_PATH_INFO'])

but only one of them is not equal to NULL.
Please note that this "issue" will affect upgrading or installation on new systems.

I would recommend to move away from using AcceptPathInfo. To normal requests with ? Because sometimes this directive hard to turn on.
