### PR TITLE
Prefer session persistent configuration over database

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -49,10 +49,10 @@ class Config {
     }
 
     function get($key, $default=null) {
-        if (isset($this->config[$key]))
-            return $this->config[$key]['value'];
-        elseif (isset($this->session[$key]))
+        if (isset($this->session[$key]))
             return $this->session[$key];
+        elseif (isset($this->config[$key]))
+            return $this->config[$key]['value'];
         elseif ($default !== null)
             return $this->set($key, $default);
         return null;


### PR DESCRIPTION
This will allow setting something in the session and having that value override the value from the database. If persist() is called for a given key, a following get() will result in the session persisted value being returned. set() will still save the value in the database.

This is mostly useful for last-mile scenarios (and future plugins) that need to affect the configuration of the system without altering the data in the configuration table.
