### PR TITLE
client email not being trimmed?

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1812,6 +1812,11 @@ class Ticket {
     function create($vars, &$errors, $origin, $autorespond=true, $alertstaff=true) {
         global $ost, $cfg, $thisclient, $_FILES;
 
+        // Drop extra whitespace
+        foreach (array('email', 'phone', 'subject', 'name') as $f)
+            if (isset($vars[$f]))
+                $vars[$f] = trim($vars[$f]);
+
         //Check for 403
         if ($vars['email']  && Validator::is_email($vars['email'])) {
 

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -133,7 +133,7 @@ class Validator {
    
     /*** Functions below can be called directly without class instance. Validator::func(var..); ***/
     function is_email($email) {
-        return (preg_match('/^([*+!.&#$|\'\\%\/0-9a-z^_`{}=?~:-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,})$/i',trim(stripslashes($email))));
+        return preg_match('/^([*+!.&#$|\'\\%\/0-9a-z^_`{}=?~:-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,})$/i',$email);
     }
     function is_phone($phone) {
         /* We're not really validating the phone number but just making sure it doesn't contain illegal chars and of acceptable len */


### PR DESCRIPTION
Multiple reports on the forums:
[Not confirmed by me personally.]

client email address with spaces at the end are not being trimmed.

report 1 text:
"It seems 3 different people were putting a space after their email address when creating a ticket. I opened the problem tickets and re-saved each email address without the space and Voila! This never happened before with version 1.6 so it's either a new bug or an incredible co-incidence.

It would be nice if the PHP code stripped blank spaces from email addresses when people submit tickets. This would certainly fix the issue."

report 2 text:
I am also facing this issue with my hMailServer + EasyPhp with osTicket-1.7.0.
But I found that users putting a space in mail id while opening new ticket.
