### PR TITLE
Fix attachments posted to pipe.php

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -45,6 +45,9 @@ class Format {
         if($charset && in_array(strtolower(trim($charset)),
                 array('default','x-user-defined','iso')))
             $charset = 'ISO-8859-1';
+        
+        if (strcasecmp($charset, $encoding) === 0)
+            return $text;
 
         $original = $text;
         if(function_exists('iconv') && $charset)

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -202,8 +202,13 @@ class Mail_Parse {
             $file=array(
                     'name'  => $filename,
                     'type'  => strtolower($part->ctype_primary.'/'.$part->ctype_secondary),
-                    'data'  => $this->mime_encode($part->body, $part->ctype_parameters['charset'])
                     );
+
+            if ($part->ctype_parameters['charset'])
+                $file['data'] = $this->mime_encode($part->body,
+                    $part->ctype_parameters['charset']);
+            else
+                $file['data'] = $part->body;
 
             if(!$this->decode_bodies && $part->headers['content-transfer-encoding'])
                 $file['encoding'] = $part->headers['content-transfer-encoding'];


### PR DESCRIPTION
- Handle decoding large base64 encoded attachments better
- Avoid transcoding from one charset to the same
- Avoid encoding attachments without a declared charset
