### PR TITLE
Allow SLA to be migrated

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -48,6 +48,13 @@ class Config {
         return $this->section;
     }
 
+    function getInfo() {
+        $info = array();
+        foreach ($this->config as $key=>$setting)
+            $info[$key] = $setting['value'];
+        return $info;
+    }
+
     function get($key, $default=null) {
         if (isset($this->session[$key]))
             return $this->session[$key];
@@ -215,10 +222,7 @@ class OsticketConfig extends Config {
     }
 
     function getConfigInfo() {
-        $info = array();
-        foreach ($this->config as $key=>$setting)
-            $info[$key] = $setting['value'];
-        return $info;
+        return $this->getInfo();
     }
 
     function getTitle() {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -584,7 +584,7 @@ class Ticket {
     /**
      * Selects the appropriate service-level-agreement plan for this ticket.
      * When tickets are transfered between departments, the SLA of the new
-     * department should be applied to the ticket. This would be usefule,
+     * department should be applied to the ticket. This would be useful,
      * for instance, if the ticket is transferred to a different department
      * which has a shorter grace period, the ticket should be considered
      * overdue in the shorter window now that it is owned by the new
@@ -1133,7 +1133,7 @@ class Ticket {
         $this->reload();
 
         // Set SLA of the new department
-        if(!$this->getSLAId())
+        if(!$this->getSLAId() || $this->getSLA()->isTransient())
             $this->selectSLAId();
 
         /*** log the transfer comments as internal note - with alerts disabled - ***/
@@ -1653,6 +1653,10 @@ class Ticket {
 
         $this->logNote('Ticket Updated', $vars['note'], $thisstaff);
         $this->reload();
+
+        // Reselect SLA if transient
+        if(!$this->getSLAId() || $this->getSLA()->isTransient())
+            $this->selectSLAId();
 
         //Clear overdue flag if duedate or SLA changes and the ticket is no longer overdue.
         if($this->isOverdue()

--- a/include/staff/slaplan.inc.php
+++ b/include/staff/slaplan.inc.php
@@ -76,6 +76,16 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
         </tr>
         <tr>
             <td width="180">
+                Transient:
+            </td>
+            <td>
+                <input type="checkbox" name="transient" value="1" <?php echo $info['transient']?'checked="checked"':''; ?> >
+                SLA can be overwritten on ticket transfer or help topic
+                change
+            </td>
+        </tr>
+        <tr>
+            <td width="180">
                 Ticket Overdue Alerts:
             </td>
             <td>


### PR DESCRIPTION
Optionally, if enabled, the SLA of a ticket can change to the default SLA of a department or help topic when the ticket is transferred to a new department or changed to a different help topic.

This is mostly useful for users who have a generic help topic or department as the recipient of incoming tickets. Then, the SLA can be reassigned when the tickets leave the generic department or help topic
