### PR TITLE
Spelling, grammar and readability fixups

### DIFF
--- a/include/ajax.content.php
+++ b/include/ajax.content.php
@@ -39,7 +39,7 @@ class ContentAjaxAPI extends AjaxController {
         $content='
 <div style="width:680px;">
     <h2>Ticket Variables</h2>
-    Please note that non-base variables depends on the context of use. Visit osTicket Wiki for up to date documentation.
+    Please note that non-base variables depend on the context of use. Visit osTicket Wiki for up-to-date documentation.
     <br/>
     <table width="100%" border="0" cellspacing=1 cellpadding=2>
         <tr><td width="55%" valign="top"><b>Base Variables</b></td><td><b>Other Variables</b></td></tr>

--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -159,7 +159,7 @@ class PipeApiController extends TicketApiController {
         if(($ticket=$pipe->processEmail()))
            return $pipe->response(201, $ticket->getNumber());
 
-        return $pipe->exerr(416, 'Request failed -retry again!');
+        return $pipe->exerr(416, 'Request failed - retry again!');
     }
 }
 

--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -362,11 +362,11 @@ class Dept {
         } elseif(strlen($vars['name'])<4) {
             $errors['name']='Name is too short.';
         } elseif(($did=Dept::getIdByName($vars['name'])) && $did!=$id) {
-            $errors['name']='Department already exist';
+            $errors['name']='Department already exists';
         }
 
         if(!$vars['ispublic'] && ($vars['id']==$cfg->getDefaultDeptId()))
-            $errors['ispublic']='System default department can not be private';
+            $errors['ispublic']='System default department cannot be private';
 
         if($errors) return false;
 

--- a/include/class.email.php
+++ b/include/class.email.php
@@ -224,11 +224,11 @@ class Email {
         if(!$vars['email'] || !Validator::is_email($vars['email'])) {
             $errors['email']='Valid email required';
         }elseif(($eid=Email::getIdByEmail($vars['email'])) && $eid!=$id) {
-            $errors['email']='Email already exits';
+            $errors['email']='Email already exists';
         }elseif($cfg && !strcasecmp($cfg->getAdminEmail(), $vars['email'])) {
             $errors['email']='Email already used as admin email!';
         }elseif(Staff::getIdByEmail($vars['email'])) { //make sure the email doesn't belong to any of the staff 
-            $errors['email']='Email in-use by a staff member';
+            $errors['email']='Email in use by a staff member';
         }
 
         if(!$vars['name'])
@@ -284,7 +284,7 @@ class Email {
                 $sql.=' AND email_id!='.db_input($id);
                 
             if(db_num_rows(db_query($sql)))
-                $errors['userid']=$errors['host']='Host/userid combination already in-use.';
+                $errors['userid']=$errors['host']='Host/userid combination already in use.';
         }
         
         $passwd=$vars['passwd']?$vars['passwd']:$vars['cpasswd'];
@@ -322,7 +322,7 @@ class Email {
                            ));
             $mail = $smtp->connect();
             if(PEAR::isError($mail)) {
-                $errors['err']='Unable to login. Check SMTP settings.';
+                $errors['err']='Unable to log in. Check SMTP settings.';
                 $errors['smtp']='<br>'.$mail->getMessage();
             }else{
                 $smtp->disconnect(); //Thank you, sir!

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -424,7 +424,7 @@ class Filter {
         if(!$vars['name'])
             $errors['name'] = 'Name required';
         elseif(($sid=self::getIdByName($vars['name'])) && $sid!=$id)
-            $errors['name'] = 'Name already in-use';
+            $errors['name'] = 'Name already in use';
 
         if(!$errors && !self::validate_rules($vars,$errors) && !$errors['rules'])
             $errors['rules'] = 'Unable to validate rules as entered';

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -545,7 +545,7 @@ class MailFetcher {
                         "\nHost: ".$fetcher->getHost().
                         "\nError: ".$fetcher->getLastError().
                         "\n\n ".$errors.' consecutive errors. Maximum of '.$MAXERRORS. ' allowed'.
-                        "\n\n This could be connection issues related to the mail server. Next delayed login attempt in aprox. $TIMEOUT minutes";
+                        "\n\n This could be connection issues related to the mail server. Next delayed login attempt in approx. $TIMEOUT minutes";
                     $ost->alertAdmin('Mail Fetch Failure Alert', $msg, true);
                 }
             }

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -672,14 +672,14 @@ class Staff {
         if(!$vars['username'] || strlen($vars['username'])<2)
             $errors['username']='Username required';
         elseif(($uid=Staff::getIdByUsername($vars['username'])) && $uid!=$id)
-            $errors['username']='Username already in-use';
+            $errors['username']='Username already in use';
 
         if(!$vars['email'] || !Validator::is_email($vars['email']))
             $errors['email']='Valid email required';
         elseif(Email::getIdByEmail($vars['email']))
             $errors['email']='Already in-use system email';
         elseif(($uid=Staff::getIdByEmail($vars['email'])) && $uid!=$id)
-            $errors['email']='Email already in-use by another staff member';
+            $errors['email']='Email already in use by another staff member';
 
         if($vars['phone'] && !Validator::is_phone($vars['phone']))
             $errors['phone']='Valid number required';

--- a/include/class.template.php
+++ b/include/class.template.php
@@ -34,7 +34,7 @@ class EmailTemplateGroup {
             'desc'=>'Notice sent to user, if enabled, on new ticket created by staff on their behalf (e.g phone calls).'),
         'ticket.overlimit'=>array(
             'name'=>'Over Limit Notice',
-            'desc'=>'A one time notice sent, if enabled, when user has reached the maximum allowed open tickets.'),
+            'desc'=>'A one-time notice sent, if enabled, when user has reached the maximum allowed open tickets.'),
         'ticket.reply'=>array(
             'name'=>'Response/Reply Template',
             'desc'=>'Template used on ticket response/reply'),
@@ -216,7 +216,7 @@ class EmailTemplateGroup {
     function update($vars,&$errors) {
 
         if(!$vars['isactive'] && $this->isInUse())
-            $errors['isactive']='Template in-use can not be disabled!';
+            $errors['isactive']='Template in use cannot be disabled!';
 
         if(!$this->save($this->getId(),$vars,$errors))
             return false;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1609,11 +1609,11 @@ class Ticket {
 
         if($vars['duedate']) {
             if($this->isClosed())
-                $errors['duedate']='Duedate can NOT be set on a closed ticket';
+                $errors['duedate']='Due date can NOT be set on a closed ticket';
             elseif(!$vars['time'] || strpos($vars['time'],':')===false)
                 $errors['time']='Select time';
             elseif(strtotime($vars['duedate'].' '.$vars['time'])===false)
-                $errors['duedate']='Invalid duedate';
+                $errors['duedate']='Invalid due date';
             elseif(strtotime($vars['duedate'].' '.$vars['time'])<=time())
                 $errors['duedate']='Due date must be in the future';
         }
@@ -1895,7 +1895,7 @@ class Ticket {
             if(!$vars['time'] || strpos($vars['time'],':')===false)
                 $errors['time']='Select time';
             elseif(strtotime($vars['duedate'].' '.$vars['time'])===false)
-                $errors['duedate']='Invalid duedate';
+                $errors['duedate']='Invalid due date';
             elseif(strtotime($vars['duedate'].' '.$vars['time'])<=time())
                 $errors['duedate']='Due date must be in the future';
         }

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -40,7 +40,7 @@ class Validator {
         if(!$source || !is_array($source))
             $this->errors['err']='Invalid input';
         elseif(!$this->fields || !is_array($this->fields))
-            $this->errors['err']='No fields setup';
+            $this->errors['err']='No fields set up';
         //Abort on error
         if($this->errors)
             return false;

--- a/include/fpdf/fpdf.php
+++ b/include/fpdf/fpdf.php
@@ -1010,13 +1010,13 @@ function Output($name='', $dest='')
 		case 'I':
 			//Send to standard output
 			if(ob_get_length())
-				$this->Error('Some data has already been output, can\'t send PDF file');
+				$this->Error('Some data has already been output. Can\'t send PDF file');
 			if(php_sapi_name()!='cli')
 			{
 				//We send to a browser
 				header('Content-Type: application/pdf');
 				if(headers_sent())
-					$this->Error('Some data has already been output, can\'t send PDF file');
+					$this->Error('Some data has already been output. Can\'t send PDF file');
 				header('Content-Length: '.strlen($this->buffer));
 				header('Content-Disposition: inline; filename="'.$name.'"');
 				header('Cache-Control: private, max-age=0, must-revalidate');
@@ -1028,10 +1028,10 @@ function Output($name='', $dest='')
 		case 'D':
 			//Download file
 			if(ob_get_length())
-				$this->Error('Some data has already been output, can\'t send PDF file');
+				$this->Error('Some data has already been output. Can\'t send PDF file');
 			header('Content-Type: application/x-download');
 			if(headers_sent())
-				$this->Error('Some data has already been output, can\'t send PDF file');
+				$this->Error('Some data has already been output. Can\'t send PDF file');
 			header('Content-Length: '.strlen($this->buffer));
 			header('Content-Disposition: attachment; filename="'.$name.'"');
 			header('Cache-Control: private, max-age=0, must-revalidate');

--- a/include/upgrader/aborted.inc.php
+++ b/include/upgrader/aborted.inc.php
@@ -20,7 +20,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
             echo '<b><font color="red">Internal error occurred - get technical help.</font></b>';
         }
         ?>
-        <p><b>For detailed - please view <a href="logs.php">system logs</a> or check your email.</b></p>
+        <p><b>For more detailed information, please view <a href="logs.php">system logs</a> or check your email.</b></p>
         <br>
         <p>Please, refer to the <a target="_blank" href="http://osticket.com/wiki/Upgrade_and_Migration">Upgrade Guide</a> on the wiki for more information.</p>
     </div>

--- a/include/upgrader/done.inc.php
+++ b/include/upgrader/done.inc.php
@@ -7,7 +7,7 @@ $_SESSION['ost_upgrader']=null;
     <div id="main">
         <h1 style="color:green;">Upgrade Completed!</h1>
         <div id="intro">
-        <p>Congratulations osTicket upgrade has been completed successfully.</p>
+        <p>Congratulations! osTicket upgrade has completed successfully.</p>
         <p>Please refer to <a href="http://osticket.com/wiki/Release_Notes" target="_blank">Release Notes</a> for more information about changes and/or new features.</p>
         </div>
         <p>Once again, thank you for choosing osTicket.</p>
@@ -20,7 +20,7 @@ $_SESSION['ost_upgrader']=null;
     </div>
     <div id="sidebar">
             <h3>What's Next?</h3>
-            <p><b>Post-upgrade</b>: You can now go to <a href="scp/settings.php" target="_blank">Admin Panel</a> to enable the system and explore the new features. For complete and upto date release notes see <a href="http://osticket.com/wiki/Release_Notes" target="_blank">osTicket wiki</a></p>
+            <p><b>Post-upgrade</b>: You can now go to <a href="scp/settings.php" target="_blank">Admin Panel</a> to enable the system and explore the new features. For complete and up-to-date release notes, see <a href="http://osticket.com/wiki/Release_Notes" target="_blank">osTicket wiki</a></p>
             <p><b>Stay up to date</b>: It's important to keep your osTicket installation up to date. Get announcements, security updates and alerts delivered directly to you! 
             <a target="_blank" href="http://osticket.com/support/subscribe.php">Get in the loop</a> today and stay informed!</p>
             <p><b>Commercial support available</b>: Get guidance and hands-on expertise to address unique challenges and make sure your osTicket runs smoothly, efficiently, and securely. <a target="_blank" href="http://osticket.com/support/commercial_support.php.php">Learn More!</a></p>

--- a/include/upgrader/prereq.inc.php
+++ b/include/upgrader/prereq.inc.php
@@ -7,7 +7,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
     <div id="main">
             <div id="intro">
              <p>Thank you for being a loyal osTicket user!</p>
-             <p>The upgrade wizard will guide you every step of the way in the upgrade process. While we try to ensure that the upgrade process is straightforward and painless, we can't guarantee it will be the case for every user.</p>
+             <p>The upgrade wizard will guide you every step of the way through the upgrade process. While we try to ensure that the upgrade process is straightforward and painless, we can't guarantee this will be the case for every user.</p>
             </div>
             <h2>Getting ready!</h2>
             <p>Before we begin, we'll check your server configuration to make sure you meet the minimum requirements to run the latest version of osTicket.</p>
@@ -19,11 +19,11 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
                 <li class="<?php echo $upgrader->check_mysql()?'yes':'no'; ?>">
                 MySQL v4.4 or greater - (<small><b><?php echo extension_loaded('mysql')?'module loaded':'missing!'; ?></b></small>)</li>
             </ul>
-            <h3>Higly Recommended:</h3>
+            <h3>Highly Recommended:</h3>
             We highly recommend that you follow the steps below.
             <ul>
-                <li>Backup the current database, if you haven't done so already.</li>
-                <li>Be patient the upgrade process will take a couple of seconds.</li>
+                <li>Back up the current database if you haven't done so already.</li>
+                <li>Be patient. The upgrade process will take a couple of seconds.</li>
             </ul>
             <div id="bar">
                 <form method="post" action="upgrade.php" id="prereq">
@@ -35,10 +35,10 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
     </div>
     <div id="sidebar">
             <h3>Upgrade Tips</h3>
-            <p>1. Remember to backup your osTicket database</p>
-            <p>2. Refer to <a href="http://osticket.com/wiki/Upgrade_and_Migration" target="_blank">Upgrade Guide</a> for the latest tips</a>
+            <p>1. Remember to back up your osTicket database</p>
+            <p>2. Refer to the <a href="http://osticket.com/wiki/Upgrade_and_Migration" target="_blank">Upgrade Guide</a> for the latest tips</a>
             <p>3. If you experience any problems, you can always restore your files/dabase backup.</p>
-            <p>4. We can help, feel free to <a href="http://osticket.com/support/" target="_blank">contact us </a> for professional help.</p>
+            <p>4. We can help! Feel free to <a href="http://osticket.com/support/" target="_blank">contact us </a> for professional help.</p>
 
     </div>
     <div class="clear"></div>

--- a/include/upgrader/rename.inc.php
+++ b/include/upgrader/rename.inc.php
@@ -27,7 +27,7 @@ if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->isAdmin()) die('Access D
     <div id="sidebar">
             <h3>Need Help?</h3>
             <p>
-            If you are looking for a greater level of support, we provide <u>professional upgrade</u> and commercial support with guaranteed response times, and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs. <a target="_blank" href="http://osticket.com/support/professional_services.php">Learn More!</a>
+            If you are looking for a greater level of support, we provide <u>professional upgrade</u> and commercial support with guaranteed response times and access to the core development team. We can also help customize osTicket or even add new features to the system to meet your unique needs. <a target="_blank" href="http://osticket.com/support/professional_services.php">Learn More!</a>
             </p>
     </div>
     <div class="clear"></div>

--- a/include/upgrader/upgrade.inc.php
+++ b/include/upgrader/upgrade.inc.php
@@ -18,14 +18,14 @@ $action=$upgrader->getNextAction();
     <div id="main">
             <div id="intro">
              <p>Thank you for taking the time to upgrade your osTicket intallation!</p>
-             <p>Please don't cancel or close the browser, any errors at this stage will be fatal.</p>
+             <p>Please don't cancel or close the browser; any errors at this stage will be fatal.</p>
             </div>
             <h2 id="task"><?php echo $action ?></h2>
             <p>The upgrade wizard will now attempt to upgrade your database and core settings!</p>
             <ul>
                 <li>Database enhancements</li>
                 <li>New and updated features</li>
-                <li>Enhance settings and security</li>
+                <li>Enhanced settings and security</li>
             </ul>
             <div id="bar">
                 <form method="post" action="upgrade.php" id="upgrade">
@@ -39,9 +39,9 @@ $action=$upgrader->getNextAction();
     </div>
     <div id="sidebar">
             <h3>Upgrade Tips</h3>
-            <p>1. Be patient the process will take a couple of minutes.</p>
+            <p>1. Be patient. The process will take a couple of minutes.</p>
             <p>2. If you experience any problems, you can always restore your files/database backup.</p>
-            <p>3. We can help, feel free to <a href="http://osticket.com/support/" target="_blank">contact us </a> for professional help.</p>
+            <p>3. We can help! Feel free to <a href="http://osticket.com/support/" target="_blank">contact us </a> for professional help.</p>
     </div>
     <div class="clear"></div>
     <div id="upgrading">


### PR DESCRIPTION
Spelling, grammar and readability in upgrader documents
- Tweaked spelling, grammar and wording to make the text of the upgrader
  pages more readable.

Fixed spelling regression
- Higly —> Highly

Spelling and readability fixes for /include/class.\* files
- Fixed some spelling mistakes

A couple more spelling/readability fixes.
- More fixes
