### PR TITLE
Make API requests stateless

### DIFF
--- a/api/api.inc.php
+++ b/api/api.inc.php
@@ -14,6 +14,13 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 file_exists('../main.inc.php') or die('System Error');
+
+// Disable sessions for the API. API should be considered stateless and
+// shouldn't chew up database records to store sessions
+if (!function_exists('noop')) { function noop() {} }
+session_set_save_handler('noop','noop','noop','noop','noop','noop');
+define('DISABLE_SESSION', true);
+
 require_once('../main.inc.php');
 require_once(INCLUDE_DIR.'class.http.php');
 require_once(INCLUDE_DIR.'class.api.php');

--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -26,7 +26,7 @@ class osTicketSession {
         if(!$this->ttl)
             $this->ttl=SESSION_TTL;
 
-        if (!OsticketConfig::getDBVersion()) {
+        if (!defined('DISABLE_SESSION') && !OsticketConfig::getDBVersion()) {
             //Set handlers.
             session_set_save_handler(
                 array(&$this, 'open'),


### PR DESCRIPTION
Disable DB session storage. This chews up database space and processing time for a request that will never resume the same session (given the current API model anyway).
