### PR TITLE
Fallback to base64_decode if imap_base64 fails

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -181,7 +181,9 @@ class MailFetcher {
             $text=imap_binary($text);
             break;
             case 3:
-            $text=imap_base64($text);
+            // imap_base64 implies strict mode. If it refuses to decode the
+            // data, then fallback to base64_decode in non-strict mode
+            $text = (($conv=imap_base64($text))) ? $conv : base64_decode($text);
             break;
             case 4:
             $text=imap_qprint($text);


### PR DESCRIPTION
Some mail clients and servers (like the ones developed in the northwestern 
United States) sometimes place encoded and non-encoded data in an email body
declared with "Content-Transfer-Encoding: base64". imap_base64 will refuse to
decode the body if it contains non base64 characters (like a period, colon,
apostrophe, etc). This patch uses base64_decode as a fallback which will make
a best effort to decode the data. In the case of our test mails, the decoded
data will contain garbage where the non-base64-encoded data was in the
original mail, but at least the message is preserved.
