### PR TITLE
Data migration tool

### DIFF
--- a/include/class.json.php
+++ b/include/class.json.php
@@ -26,6 +26,10 @@ class JsonDataParser {
         while (!feof($stream)) {
             $contents .= fread($stream, 8192);
         }
+        return self::decode($contents);
+    }
+
+    function decode($contents) {
         if (function_exists("json_decode")) {
             return json_decode($contents, true);
         } else {
@@ -56,7 +60,11 @@ class JsonDataParser {
 
 class JsonDataEncoder {
     function encode($var) {
-        $decoder = new Services_JSON();
-        return $decoder->encode($var);
+        if (function_exists('json_encode'))
+            return json_encode($var);
+        else {
+            $decoder = new Services_JSON();
+            return $decoder->encode($var);
+        }
     }
 }

--- a/include/mysql.php
+++ b/include/mysql.php
@@ -198,4 +198,8 @@
     function db_errno() {
         return mysql_errno();
     }
+
+    function db_field_type($res, $col=0) {
+        return mysql_field_type($res, $col);
+    }
 ?>

--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -214,6 +214,11 @@ function db_input($var, $quote=true) {
     return db_real_escape($var, $quote);
 }
 
+function db_field_type($res, $col=0) {
+    global $__db;
+    return $res->fetch_field_direct($col);
+}
+
 function db_connect_error() {
     global $__db;
     return $__db->connect_error;

--- a/setup/cli/manage.php
+++ b/setup/cli/manage.php
@@ -13,7 +13,7 @@ class Manager extends Module {
 
     var $usage = '$script action [options] [arguments]';
 
-    var $autohelp = false;
+    var $autohelp = true;
 
     function showHelp() {
         foreach (glob(dirname(__file__).'/modules/*.php') as $script)

--- a/setup/cli/manage.php
+++ b/setup/cli/manage.php
@@ -3,6 +3,9 @@
 
 require_once "modules/class.module.php";
 
+if (!function_exists('noop')) { function noop() {} }
+session_set_save_handler('noop','noop','noop','noop','noop','noop');
+
 class Manager extends Module {
     var $prologue =
         "Manage one or more osTicket installations";
@@ -13,7 +16,7 @@ class Manager extends Module {
 
     var $usage = '$script action [options] [arguments]';
 
-    var $autohelp = true;
+    var $autohelp = false;
 
     function showHelp() {
         foreach (glob(dirname(__file__).'/modules/*.php') as $script)
@@ -31,12 +34,12 @@ class Manager extends Module {
             echo str_pad($name, 20) . $mod->prologue . "\n";
     }
 
-    function run() {
-        if ($this->getOption('help') && !$this->getArgument('action'))
+    function run($args, $options) {
+        if ($options['help'] && !$args['action'])
             $this->showHelp();
 
         else {
-            $action = $this->getArgument('action');
+            $action = $args['action'];
 
             global $argv;
             foreach ($argv as $idx=>$val)
@@ -45,8 +48,11 @@ class Manager extends Module {
 
             foreach (glob(dirname(__file__).'/modules/*.php') as $script)
                 include_once $script;
-            $module = Module::getInstance($action);
-            $module->_run();
+            if (($module = Module::getInstance($action)))
+                return $module->_run($args['action']);
+
+            $this->stderr->write("Unknown action given\n");
+            $this->showHelp();
         }
     }
 }
@@ -56,6 +62,6 @@ if (php_sapi_name() != "cli")
 
 $manager = new Manager();
 $manager->parseOptions();
-$manager->run();
+$manager->_run(basename(__file__));
 
 ?>

--- a/setup/cli/modules/export.php
+++ b/setup/cli/modules/export.php
@@ -1,0 +1,94 @@
+<?php
+/*********************************************************************
+    cli/export.php
+
+    osTicket data exporter, used for migration and backup
+
+    Jared Hancock <jared@osticket.com>
+    Copyright (c)  2006-2013 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+require_once dirname(__file__) . "/class.module.php";
+
+require_once dirname(__file__) . '/../../../main.inc.php';
+
+require_once INCLUDE_DIR . 'class.json.php';
+
+define('OSTICKET_BACKUP_SIGNATURE', 'osTicket-Backup');
+define('OSTICKET_BACKUP_VERSION', 'A');
+
+class Exporter extends Module {
+    var $prologue =
+        "Dumps the osTicket database in formats suitable for the importer";
+
+    var $tables = array(CONFIG_TABLE, SYSLOG_TABLE, FILE_TABLE,
+        FILE_CHUNK_TABLE, STAFF_TABLE, DEPT_TABLE, TOPIC_TABLE, GROUP_TABLE,
+        GROUP_DEPT_TABLE, TEAM_TABLE, TEAM_MEMBER_TABLE, FAQ_TABLE,
+        FAQ_ATTACHMENT_TABLE, FAQ_TOPIC_TABLE, FAQ_CATEGORY_TABLE,
+        CANNED_TABLE, CANNED_ATTACHMENT_TABLE, TICKET_TABLE, TICKET_THREAD_TABLE,
+        TICKET_ATTACHMENT_TABLE, TICKET_PRIORITY_TABLE, PRIORITY_TABLE,
+        TICKET_LOCK_TABLE, TICKET_EVENT_TABLE, TICKET_EMAIL_INFO_TABLE,
+        EMAIL_TABLE, EMAIL_TEMPLATE_TABLE, FILTER_TABLE, FILTER_RULE_TABLE,
+        SLA_TABLE, API_KEY_TABLE, TIMEZONE_TABLE, PAGE_TABLE);
+
+    var $options = array(
+        'stream' => array('-o', '--output', 'default'=>'compress.zlib://php://stdout',
+            "File or stream to receive the exported output. As a default,
+            zlib compressed output is sent to standard out.")
+    );
+
+    var $stream;
+
+    function write_block($what) {
+        fwrite($this->stream, JsonDataEncoder::encode($what));
+        fwrite($this->stream, "\x1e");
+    }
+
+    function run($args, $options) {
+        global $ost;
+        $this->stream = fopen($options['stream'], 'w');
+        $header = array(
+            array(OSTICKET_BACKUP_SIGNATURE, OSTICKET_BACKUP_VERSION),
+            array(
+                'version'=>THIS_VERSION,
+                'table_prefix'=>TABLE_PREFIX,
+                'salt'=>SECRET_SALT,
+            ),
+        );
+        $this->write_block($header);
+
+        foreach ($this->tables as $t) {
+            $this->stderr->write("$t\n");
+            // Inspect schema
+            $table = $indexes = array();
+            $res = db_query("show columns from $t");
+            while ($field = db_fetch_array($res))
+                $table[] = $field;
+
+            $res = db_query("show indexes from $t");
+            while ($col = db_fetch_array($res))
+                $indexes[] = $col;
+
+            $res = db_query("select * from $t");
+            $types = array();
+
+            $this->write_block(
+                array('table', substr($t, strlen(TABLE_PREFIX)), $table,
+                    $indexes));
+
+            // Dump row data
+            while ($row = db_fetch_row($res))
+                $this->write_block($row);
+
+            $this->write_block(array('end-table'));
+        }
+    }
+}
+
+Module::register('export', 'Exporter');
+?>

--- a/setup/cli/modules/import.php
+++ b/setup/cli/modules/import.php
@@ -1,0 +1,241 @@
+<?
+/*********************************************************************
+    cli/import.php
+
+    osTicket data importer, used for migration and backup recovery
+
+    Jared Hancock <jared@osticket.com>
+    Copyright (c)  2006-2013 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+require_once dirname(__file__) . "/class.module.php";
+
+require_once dirname(__file__) . '/../../../main.inc.php';
+
+require_once INCLUDE_DIR . 'class.json.php';
+
+class Importer extends Module {
+    var $prologue =
+        "Imports data from a previous backup (using the exporter)";
+
+    var $options = array(
+        'stream' => array('-i', '--input', 'default'=>'php://stdin',
+            'metavar'=>'FILE', 'help'=>
+            "File or stream from which to read the export. As a default,
+            data is received from standard in."),
+        'compress' => array('-z', '--compress', 'action'=>'store_true',
+            'help'=>'Read zlib compressed data (use -z with the export
+                command)'),
+        'tables' => array('-t', '--table', 'action'=>'append',
+            'metavar'=>'TABLE', 'help'=>
+            "Table to be restored from the backup. Default is to restore all
+            tables. This option can be specified more than once"),
+        'drop' => array('-D', '--drop', 'action'=>'store_true', 'help'=>
+            'Issue DROP TABLE statements before the create statemente'),
+    );
+
+    var $epilog =
+        "The SQL of the import is written to standard outout";
+
+    var $stream;
+    var $header;
+    var $source_ost_info;
+
+    function verify_header() {
+        list($header, $info) = $this->read_block();
+        if (!$header || $header[0] != OSTICKET_BACKUP_SIGNATURE) {
+            $this->stderr->write('Header mismatch -- not an osTicket backup');
+            return false;
+        }
+        else
+            $this->header = $header;
+
+        if (!$info || $info['dbtype'] != 'mysql') {
+            $this->stderr->write('Only mysql imports are supported currently');
+            return false;
+        }
+        $this->source_ost_info = $info;
+        return true;
+    }
+
+    function read_block() {
+        $block = '';
+        while (!feof($this->stream) && (($c = fgetc($this->stream)) != "\x1e"))
+            $block .= $c;
+
+        if ($json = JsonDataParser::decode($block))
+            return $json;
+
+        if (strlen($block)) {
+            $this->stderr->write("Unable to read block from input");
+            die();
+        }
+    }
+
+    function send_statement($stmt) {
+        if ($this->getOption('prime-time'))
+            db_query($stmt);
+        else {
+            $this->stdout->write($stmt);
+            $this->stdout->write(";\n");
+        }
+    }
+
+    function import_table() {
+        if (!($header = $this->read_block()))
+            return false;
+
+        else if ($header[0] != 'table') {
+            $this->stderr->write('Unable to read table header');
+            return false;
+        }
+
+        // TODO: Consider included tables and excluded tables
+
+        $this->stderr->write("Importing table: {$header[1]}\n");
+        $this->create_table($header);
+        $this->create_indexes($header);
+
+        while (($row=$this->read_block())) {
+            if (isset($row[0]) && ($row[0] == 'end-table')) {
+                $this->load_row(null, null, true);
+                return true;
+            }
+            $this->load_row($header, $row);
+        }
+        return false;
+    }
+
+    function create_table($info) {
+        if ($this->getOption('drop'))
+            $this->send_statement('DROP TABLE IF EXISTS `'.TABLE_PREFIX.'`');
+        $sql = 'CREATE TABLE `'.TABLE_PREFIX.$info[1].'` (';
+        $pk = array();
+        $fields = array();
+        foreach ($info[2] as $col) {
+            $field = "`{$col['Field']}` {$col['Type']}";
+            if ($col['Null'] == 'NO')
+                $field .= ' NOT NULL ';
+            if ($col['Default'] == 'CURRENT_TIMESTAMP')
+                $field .= ' DEFAULT CURRENT_TIMESTAMP';
+            elseif ($col['Default'] !== null)
+                $field .= ' DEFAULT '.db_input($col['Default']);
+            $field .= ' '.$col['Extra'];
+            $fields[] = $field;
+        }
+        // Generate PRIMARY KEY
+        foreach ($info[3] as $idx) {
+            if ($idx['Key_name'] == 'PRIMARY') {
+                $col = '`'.$idx['Column_name'].'`';
+                if ($idx['Collation'] != 'A')
+                    $col .= ' DESC';
+                $pk[(int)$idx['Seq_in_index']] = $col;
+            }
+        }
+        $sql .= implode(", ", $fields);
+        if ($pk)
+            $sql .= ', PRIMARY KEY ('.implode(',',$pk).')';
+        $sql .= ') DEFAULT CHARSET=utf8';
+        $queries[] = $sql;
+        $this->send_statement($sql);
+    }
+
+    function create_indexes($header) {
+        $indexes = array();
+        foreach ($header[3] as $idx) {
+            if ($idx['Key_name'] == 'PRIMARY')
+                continue;
+            if (!isset($indexes[$idx['Key_name']]))
+                $indexes[$idx['Key_name']] = array(
+                    'cols'=>array(),
+                    // XXX: Drop table-prefix
+                    'table'=>substr($idx['Table'],
+                        strlen($this->source_ost_info['table_prefix'])),
+                    'type'=>$idx['Index_type'],
+                    'unique'=>!$idx['Non_unique']);
+            $index = &$indexes[$idx['Key_name']];
+            $col = '`'.$idx['Column_name'].'`';
+            if ($idx['Collation'] != 'A')
+                $col .= ' DESC';
+            $index[(int)$idx['Seq_in_index']] = $col;
+            $index['cols'][] = $col;
+        }
+        foreach ($indexes as $name=>$info) {
+            $cols = array();
+            $this->send_statement('CREATE '
+                .(($info['unique']) ? 'UNIQUE ' : '')
+                .'INDEX `'.$name
+                .'` USING '.$info['type']
+                .' ON `'.TABLE_PREFIX.$info['table'].'` ('
+                .implode(',', $info['cols'])
+                .')');
+        }
+    }
+
+    function truncate_table($info) {
+        $this->send_statement('TRUNCATE TABLE '.TABLE_PREFIX.$info[1]);
+        $indexes = array();
+        foreach ($info[3] as $idx) {
+            if ($idx['Key_name'] == 'PRIMARY')
+                continue;
+            $indexes[$idx['Key_name']] =
+                '`'.TABLE_PREFIX.$info[1].'`.`'.$idx['Key_name'].'`';
+        }
+        foreach ($indexes as $T=>$fqn)
+            $this->send_statement('DROP INDEX IF EXISTS '.$fqn);
+    }
+
+    function load_row($info, $row, $flush=false) {
+        static $header = null;
+        static $rows = array();
+        static $length = 0;
+
+        if ($info && $header === null) {
+            $header = "INSERT INTO `".TABLE_PREFIX.$info[1].'` (';
+            $cols = array();
+            foreach ($info[2] as $col)
+                $cols[] = "`{$col['Field']}`";
+            $header .= implode(', ', $cols);
+            $header .= ") VALUES ";
+        }
+        if ($row) {
+            $values = array();
+            foreach ($info[2] as $i=>$col)
+                $values[] = (is_numeric($row[$i]))
+                    ? $row[$i]
+                    : ($row[$i] ? '0x'.bin2hex($row[$i]) : "''");
+            $values = "(" . implode(', ', $values) . ")";
+            $length += strlen($values);
+            $rows[] = &$values;
+        }
+        if (($flush || $length > 16000) && $header) {
+            $this->send_statement($header . implode(',', $rows));
+            $header = null;
+            $rows = array();
+            $length = 0;
+        }
+    }
+
+    function run($args, $options) {
+        $stream = $options['stream'];
+        if ($options['compress']) $stream = "compress.zlib://$stream";
+        if (!($this->stream = fopen($stream, 'rb'))) {
+            $this->stderr->write('Unable to open input stream');
+            die();
+        }
+
+        if (!$this->verify_header())
+            die('Unable to verify backup header');
+
+        while ($this->import_table());
+        @fclose($this->stream);
+    }
+}
+
+Module::register('import', 'Importer');
+?>


### PR DESCRIPTION
This feature adds the ability to backup osTicket data and import it into a new osTicket installation. The schema of the database is preserved export and recreated in the import. Therefore, the database migration process should be able to recover organically from a recovered backup.

**Outstanding:**
- Partial imports (excluding and including tables by name)
- Documentation page (in `setup/doc`)
- One click backup+download from the web
