### PR TITLE
Logo is not displayed in the offline page

### DIFF
--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -21,7 +21,7 @@ header("Content-Type: text/html; charset=UTF-8\r\n");
     <div id="container">
         <div id="header">
             <a id="logo" href="<?php echo ROOT_PATH; ?>index.php"
-            title="Support Center"><img src="logo.php" border=0 alt="<?php
+            title="Support Center"><img src="<?php echo ROOT_PATH; ?>logo.php" border=0 alt="<?php
                 echo $ost->getConfig()->getTitle(); ?>"
                 style="height: 5em"></a>
             <p>

--- a/offline.php
+++ b/offline.php
@@ -14,7 +14,9 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 require_once('client.inc.php');
-if(is_object($ost) && $ost->isSystemOnline()) {
+if(is_object($ost) && $ost->isSystemOnline()
+        && (!in_array(strtolower(basename($_SERVER['SCRIPT_NAME'])),
+            array('logo.php',)))) {
     @header('Location: index.php'); //Redirect if the system is online.
     include('index.php');
     exit;


### PR DESCRIPTION
After merging the custom logo patch, the logo on the offline page 
disappeared. This addresses the issue by exempting the logo.php script for 
the offline redirect in client.inc.php
