### PR TITLE
Only fetch client config on pages with file upload

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -247,23 +247,35 @@ $(document).ready(function(){
        });
 
     /* Get config settings from the backend */
-    var $config = null;
-    $.ajax({
-        url: "ajax.php/config/scp",
-        dataType: 'json',
-        async: false,
-        success: function (config) {
-            $config = config;
-            }
-        });
+    jQuery.fn.exists = function() { return this.length>0; };
 
+    var getConfig = (function() {
+        var dfd = $.Deferred();
+        return function() {
+            if (!dfd.isResolved())
+                $.ajax({
+                    url: "ajax.php/config/scp",
+                    dataType: 'json',
+                    success: function (json_config) {
+                        dfd.resolve(json_config);
+                    }
+                });
+            return dfd;
+        }
+    })();
     /* Multifile uploads */
-     $('.multifile').multifile({
-        container:   '.uploads',
-        max_uploads: ($config && $config.max_file_uploads)?$config.max_file_uploads:1,
-        file_types:  ($config && $config.file_types)?$config.file_types:".*",
-        max_file_size: ($config && $config.max_file_size)?$config.max_file_size:0
+    var elems = $('.multifile');
+    if (elems.exists()) {
+        /* Get config settings from the backend */
+        getConfig().then(function(c) {
+            elems.multifile({
+                container:   '.uploads',
+                max_uploads: c.max_file_uploads || 1,
+                file_types:  c.file_types || ".*",
+                max_file_size: c.max_file_size || 0
+            });
         });
+    }
 
     /* Datepicker */
     $('.dp').datepicker({


### PR DESCRIPTION
The client config only contains the settings for the multi-file upload 
widget. So it doesn't need to be fetched unless the widget exists on the page
