### PR TITLE
Add web.config for IIS to serve the API

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <configSections>
+        <sectionGroup name="system.webServer">
+            <sectionGroup name="rewrite">
+                <section name="rewriteMaps" overrideModeDefault="Allow" />
+                <section name="rules" overrideModeDefault="Allow" />
+            </sectionGroup>
+        </sectionGroup>
+    </configSections>
+
+    <system.webServer>
+        <directoryBrowse enabled="false" />
+        <rewrite>
+            <rules>
+                <rule name="HTTP api" stopProcessing="true">
+                    <match url="^(.*/)?api/(.*)$" ignoreCase="true"/>
+                    <conditions>
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile"
+                            ignoreCase="false" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory"
+                            ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="{R:1}api/http.php/{R:2}"/>
+                </rule>
+                <rule name="Site pages" stopProcessing="true">
+                    <match url="^(.*/)?pages/(.*)$" ignoreCase="true"/>
+                    <conditions>
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile"
+                            ignoreCase="false" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory"
+                            ignoreCase="false" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="{R:1}pages/index.php/{R:2}"/>
+                </rule>
+            </rules>
+        </rewrite>
+        <defaultDocument>
+            <files>
+                <remove value="index.php" />
+                <add value="index.php" />
+            </files>
+        </defaultDocument>
+    </system.webServer>
+
+</configuration>


### PR DESCRIPTION
The API was broken when running on IIS because the rewrite engine needs to be configured to rewrite the requests to `api/http.php`.

**Outstanding**:
- Add `pages/blah` rewritten URLs
