### PR TITLE
Properly escape HTML chars in text/plain email bodies

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -342,13 +342,15 @@ class MailFetcher {
     function getBody($mid) {
 
         $body ='';
-        if(!($body = $this->getPart($mid,'TEXT/PLAIN', $this->charset))) {
-            if(($body = $this->getPart($mid,'TEXT/HTML', $this->charset))) {
-                //Convert tags of interest before we striptags
-                $body=str_replace("</DIV><DIV>", "\n", $body);
-                $body=str_replace(array("<br>", "<br />", "<BR>", "<BR />"), "\n", $body);
-                $body=Format::safe_html($body); //Balance html tags & neutralize unsafe tags.
-            }
+        if ($body = $this->getPart($mid,'TEXT/PLAIN', $this->charset))
+            // The Content-Type was text/plain, so escape anything that
+            // looks like HTML
+            $body=Format::htmlchars($body);
+        elseif ($body = $this->getPart($mid,'TEXT/HTML', $this->charset)) {
+            //Convert tags of interest before we striptags
+            $body=str_replace("</DIV><DIV>", "\n", $body);
+            $body=str_replace(array("<br>", "<br />", "<BR>", "<BR />"), "\n", $body);
+            $body=Format::safe_html($body); //Balance html tags & neutralize unsafe tags.
         }
 
         return $body;

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -146,13 +146,13 @@ class Mail_Parse {
     function getBody(){
 
         $body='';
-        if(!($body=$this->getPart($this->struct,'text/plain'))) {
-            if(($body=$this->getPart($this->struct,'text/html'))) {
-                //Cleanup the html.
-                $body=str_replace("</DIV><DIV>", "\n", $body);
-                $body=str_replace(array("<br>", "<br />", "<BR>", "<BR />"), "\n", $body);
-                $body=Format::safe_html($body); //Balance html tags & neutralize unsafe tags.
-            }
+        if($body=$this->getPart($this->struct,'text/plain'))
+            $body = Format::htmlchars($body);
+        elseif($body=$this->getPart($this->struct,'text/html')) {
+            //Cleanup the html.
+            $body=str_replace("</DIV><DIV>", "\n", $body);
+            $body=str_replace(array("<br>", "<br />", "<BR>", "<BR />"), "\n", $body);
+            $body=Format::safe_html($body); //Balance html tags & neutralize unsafe tags.
         }
         return $body;
     }

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -146,6 +146,10 @@ class Thread {
         //Add ticket Id.
         $vars['ticketId'] = $this->getTicketId();
 
+        // DELME: When HTML / rich-text is supported
+        $vars['title'] = Format::htmlchars($vars['title']);
+        $vars['body'] = Format::htmlchars($vars['body']);
+
         return Note::create($vars, $errors);
     }
 
@@ -154,12 +158,20 @@ class Thread {
         $vars['ticketId'] = $this->getTicketId();
         $vars['staffId'] = 0;
 
+        // DELME: When HTML / rich-text is supported
+        $vars['title'] = Format::htmlchars($vars['title']);
+        $vars['body'] = Format::htmlchars($vars['body']);
+
         return Message::create($vars, $errors);
     }
 
     function addResponse($vars, &$errors) {
 
         $vars['ticketId'] = $this->getTicketId();
+
+        // DELME: When HTML / rich-text is supported
+        $vars['title'] = Format::htmlchars($vars['title']);
+        $vars['body'] = Format::htmlchars($vars['body']);
 
         return Response::create($vars, $errors);
     }


### PR DESCRIPTION
If there characters in the plain text body of the email that appear like
HTML tags, for instance

```
From: <sip:527772432@172.18.0.2>;tag=952422a9dd1ap1a6o1
```

The <sip...> part would be removed by the Format::striptags() call in
Format::sanitize().
