### PR TITLE
Inline Attachments

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -415,7 +415,7 @@ class ApiEmailDataParser extends EmailDataParser {
         $data['source'] = 'Email';
 
         if(!$data['message'])
-            $data['message'] = $data['subject']?$data['subject']:'(EMPTY)';
+            $data['message'] = $data['subject']?$data['subject']:'-';
 
         if(!$data['subject'])
             $data['subject'] = '[No Subject]';

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -388,7 +388,7 @@ class MailFetcher {
 
         //An email with just attachments can have empty body.
         if(!$vars['message'])
-            $vars['message'] = '(EMPTY)';
+            $vars['message'] = '-';
 
         if($ost->getConfig()->useEmailPriority())
             $vars['priorityId']=$this->getPriority($mid);
@@ -429,7 +429,6 @@ class MailFetcher {
         if($message
                 && $ost->getConfig()->allowEmailAttachments()
                 && ($struct = imap_fetchstructure($this->mbox, $mid))
-                && $struct->parts
                 && ($attachments=$this->getAttachments($struct))) {
 
             foreach($attachments as $a ) {

--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -17,9 +17,9 @@ if(!$dept || !$dept->isPublic())
                 <a href="view.php?id=<?php echo $ticket->getExtId(); ?>" title="Reload"><span class="Icon refresh">&nbsp;</span></a>
             </h1>
         </td>
-    </tr> 
+    </tr>
     <tr>
-        <td width="50%">   
+        <td width="50%">
             <table class="infoTable" cellspacing="1" cellpadding="3" width="100%" border="0">
                 <tr>
                     <th width="100">Ticket Status:</th>
@@ -58,10 +58,13 @@ if(!$dept || !$dept->isPublic())
 <br>
 <span class="Icon thread">Ticket Thread</span>
 <div id="ticketThread">
-<?php    
+<?php
 if($ticket->getThreadCount() && ($thread=$ticket->getClientThread())) {
     $threadType=array('M' => 'message', 'R' => 'response');
     foreach($thread as $entry) {
+        if($entry['body'], '-')
+            $entry['body'] = '(EMPTY)';
+
         //Making sure internal notes are not displayed due to backend MISTAKES!
         if(!$threadType[$entry['thread_type']]) continue;
         $poster = $entry['poster'];

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -54,7 +54,7 @@ if($ticket->isOverdue())
             <?php if($thisstaff->canDeleteTickets()) { ?>
                 <a id="ticket-delete" class="action-button" href="#delete"><i class="icon-trash"></i> Delete</a>
             <?php } ?>
-            <?php 
+            <?php
             if($thisstaff->canCloseTickets()) {
                 if($ticket->isOpen()) {?>
                 <a id="ticket-close" class="action-button" href="#close"><i class="icon-remove-circle"></i> Close</a>
@@ -63,18 +63,18 @@ if($ticket->isOverdue())
                 <a id="ticket-reopen" class="action-button" href="#reopen"><i class="icon-undo"></i> Reopen</a>
                 <?php
                 } ?>
-            <?php 
+            <?php
             } ?>
-            <?php 
+            <?php
             if($thisstaff->canEditTickets()) { ?>
                 <a class="action-button" href="tickets.php?id=<?php echo $ticket->getId(); ?>&a=edit"><i class="icon-edit"></i> Edit</a>
-            <?php 
+            <?php
             } ?>
 
             <?php
             if($ticket->isOpen() && !$ticket->isAssigned() && $thisstaff->canAssignTickets()) {?>
                 <a id="ticket-claim" class="action-button" href="#claim"><i class="icon-user"></i> Claim</a>
-                
+
             <?php
             }?>
 
@@ -82,19 +82,19 @@ if($ticket->isOverdue())
 
             <div id="action-dropdown-more" class="action-dropdown anchor-right">
               <ul>
-                <?php 
+                <?php
                 if($ticket->isOpen() && ($dept && $dept->isManager($thisstaff))) {
-                        
+
                     if($ticket->isAssigned()) { ?>
                         <li><a id="ticket-release" href="#release"><i class="icon-user"></i> Release (unassign) Ticket</a></li>
                     <?php
                     }
-                    
+
                     if(!$ticket->isOverdue()) { ?>
                         <li><a id="ticket-overdue" href="#overdue"><i class="icon-bell"></i> Mark as Overdue</a></li>
                     <?php
                     }
-                    
+
                     if($ticket->isAnswered()) { ?>
                         <li><a id="ticket-unanswered" href="#unanswered"><i class="icon-circle-arrow-left"></i> Mark as Unanswered</a></li>
                     <?php
@@ -103,11 +103,11 @@ if($ticket->isOverdue())
                     <?php
                     }
                 }
-              
-                if($thisstaff->canBanEmails()) { 
+
+                if($thisstaff->canBanEmails()) {
                      if(!$emailBanned) {?>
                         <li><a id="ticket-banemail" href="#banemail"><i class="icon-ban-circle"></i> Ban Email (<?php echo $ticket->getEmail(); ?>)</a></li>
-                <?php 
+                <?php
                      } elseif($unbannable) { ?>
                         <li><a id="ticket-banemail" href="#unbanemail"><i class="icon-undo"></i> Unban Email (<?php echo $ticket->getEmail(); ?>)</a></li>
                     <?php
@@ -179,13 +179,13 @@ if($ticket->isOverdue())
                 </tr>
                 <tr>
                     <th>Source:</th>
-                    <td><?php 
+                    <td><?php
                         echo Format::htmlchars($ticket->getSource());
 
                         if($ticket->getIP())
                             echo '&nbsp;&nbsp; <span class="faded">('.$ticket->getIP().')</span>';
 
-                    
+
                         ?>
                     </td>
                 </tr>
@@ -306,8 +306,8 @@ if(!$cfg->showNotesInline()) { ?>
                 </td>
             </tr>
             <?php
-             if($note['attachments'] 
-                    && ($tentry=$ticket->getThreadEntry($note['id'])) 
+             if($note['attachments']
+                    && ($tentry=$ticket->getThreadEntry($note['id']))
                     && ($links=$tentry->getAttachmentsLinks())) { ?>
             <tr>
                 <td class="info" colspan="2"><?php echo $links; ?></td>
@@ -332,6 +332,8 @@ if(!$cfg->showNotesInline()) { ?>
         $types[] = 'N';
     if(($thread=$ticket->getThreadEntries($types))) {
        foreach($thread as $entry) {
+           if($entry['body'], '-')
+               $entry['body'] = '(EMPTY)';
            ?>
         <table class="<?php echo $threadTypes[$entry['thread_type']]; ?>" cellspacing="0" cellpadding="1" width="940" border="0">
             <tr>
@@ -341,7 +343,7 @@ if(!$cfg->showNotesInline()) { ?>
             </tr>
             <tr><td colspan=3><?php echo Format::display($entry['body']); ?></td></tr>
             <?php
-            if($entry['attachments'] 
+            if($entry['attachments']
                     && ($tentry=$ticket->getThreadEntry($entry['id']))
                     && ($links=$tentry->getAttachmentsLinks())) {?>
             <tr>
@@ -518,7 +520,7 @@ if(!$cfg->showNotesInline()) { ?>
         <input type="hidden" name="locktime" value="<?php echo $cfg->getLockTime(); ?>">
         <input type="hidden" name="a" value="postnote">
         <table border="0" cellspacing="0" cellpadding="3">
-            <?php 
+            <?php
             if($errors['postnote']) {?>
             <tr>
                 <td width="160">&nbsp;</td>
@@ -569,7 +571,7 @@ if(!$cfg->showNotesInline()) { ?>
                         <option value="" selected="selected">&mdash; unchanged &mdash;</option>
                         <?php
                         $state = $info['state'];
-                        if($ticket->isClosed()){ 
+                        if($ticket->isClosed()){
                             echo sprintf('<option value="open" %s>Reopen Ticket</option>',
                                     ($state=='reopen')?'selected="selelected"':'');
                         } else {
@@ -579,12 +581,12 @@ if(!$cfg->showNotesInline()) { ?>
 
                             /* Ticket open - states */
                             echo '<option value="" disabled="disabled">&mdash; Ticket States &mdash;</option>';
-                       
+
                             //Answer - state
                             if($ticket->isAnswered())
                                 echo sprintf('<option value="unanswered" %s>Mark As Unanswered</option>',
                                     ($state=='unanswered')?'selected="selelected"':'');
-                            else 
+                            else
                                 echo sprintf('<option value="answered" %s>Mark As Answered</option>',
                                     ($state=='answered')?'selected="selelected"':'');
 
@@ -681,7 +683,7 @@ if(!$cfg->showNotesInline()) { ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="a" value="assign">
         <table border="0" cellspacing="0" cellpadding="3">
-                
+
             <?php
             if($errors['assign']) {
                 ?>
@@ -837,7 +839,7 @@ if(!$cfg->showNotesInline()) { ?>
     </p>
     <p class="confirm-action" style="display:none;" id="answered-confirm">
         Are you sure want to flag the ticket as <b>answered</b>?
-    </p>    
+    </p>
     <p class="confirm-action" style="display:none;" id="unanswered-confirm">
         Are you sure want to flag the ticket as <b>unanswered</b>?
     </p>


### PR DESCRIPTION
Addresses issue #398
- Scan for inline attachments - Incoming messages with empty body and an inline attachment might not have parts - depending on encoding used.
- Use "-" tag for emails with empty body/message
