### PR TITLE
Avoid extra db query for schema signature

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -192,7 +192,8 @@ class OsticketConfig extends Config {
 
     function getSchemaSignature($section=null) {
 
-        if (!$section && ($v=$this->get('schema_signature')))
+        if ((!$section || $section == $this->section)
+                && ($v=$this->get('schema_signature')))
             return $v;
 
         // 1.7 after namespaced configuration, other namespace


### PR DESCRIPTION
This avoids a per-request unnecessary query where the schema signature retrieved from the database when the config table is scanned is not used. The original concept was for `getSchemaSignature` to receive `null` for the base schema signature. However, the actual implementation sends the name of the base stream (`core`) to `getSchemaSignature`, which results in an extra query to the database.
