### PR TITLE
Ensure no leading or trailing whitespace on the remote_addr

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -199,8 +199,10 @@
     define('TIMEZONE_TABLE',TABLE_PREFIX.'timezone');
 
     #Global overwrite
-    if($_SERVER['HTTP_X_FORWARDED_FOR']) //Can contain multiple IPs - use the last one.
-        $_SERVER['REMOTE_ADDR'] =  array_pop(explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']));
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+        // Take the left-most item for X-Forwarded-For
+        $_SERVER['REMOTE_ADDR'] = array_pop(
+            explode(',', trim($_SERVER['HTTP_X_FORWARDED_FOR'])));
 
     #Connect to the DB && get configuration from database
     $ferror=null;


### PR DESCRIPTION
If reading the remote_addr from `X-Forwarded-For` header, ensure that there is no leading or trailing whitespace. If `ip_binding` is enabled for staff sessions, this could cause unexpected logouts
