### PR TITLE
Support Reply-To headers in ticket filters

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -19,7 +19,8 @@ class TicketApiController extends ApiController {
         );
 
         if(!strcasecmp($format, 'email'))
-            $supported = array_merge($supported, array('header', 'mid', 'emailId', 'ticketId'));
+            $supported = array_merge($supported, array('header', 'mid',
+                'emailId', 'ticketId', 'reply-to', 'reply-to-name'));
 
         return $supported;
     }

--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -651,8 +651,10 @@ class TicketFilter {
                      'subject'   => $vars['subject'],
                      'name'      => $vars['name'],
                      'body'      => $vars['message'],
-                     'emailId'   => $vars['emailId'])
-                 ));
+                     'emailId'   => $vars['emailId'],
+                     'reply-to'  => @$vars['reply-to'],
+                     'reply-to-name' => @$vars['reply-to-name'],
+                 )));
 
          //Init filters.
         $this->build();

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -235,6 +235,11 @@ class MailFetcher {
                       'header' => $this->getHeader($mid),
                       );
 
+        if ($replyto = $headerinfo->reply_to) {
+            $header['reply-to'] = $replyto[0]->mailbox.'@'.$replyto[0]->host;
+            $header['reply-to-name'] = $replyto[0]->personal;
+        }
+
         //Try to determine target email - useful when fetched inbox has
         // aliases that are independent emails within osTicket.
         $emailId = 0;
@@ -399,14 +404,11 @@ class MailFetcher {
         if($mailinfo['mid'] && ($id=Ticket::getIdByMessageId($mailinfo['mid'], $mailinfo['email'])))
             return true; //Reporting success so the email can be moved or deleted.
 
-        $vars = array();
-        $vars['email']=$mailinfo['email'];
+        $vars = $mailinfo;
         $vars['name']=$this->mime_decode($mailinfo['name']);
         $vars['subject']=$mailinfo['subject']?$this->mime_decode($mailinfo['subject']):'[No Subject]';
         $vars['message']=Format::stripEmptyLines($this->getBody($mid));
-        $vars['header']=$mailinfo['header'];
         $vars['emailId']=$mailinfo['emailId']?$mailinfo['emailId']:$this->getEmailId();
-        $vars['mid']=$mailinfo['mid'];
 
         //Missing FROM name  - use email address.
         if(!$vars['name'])

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -152,6 +152,10 @@ class Mail_Parse {
         return $this->struct->headers['subject'];
     }
 
+    function getReplyTo() {
+        return Mail_Parse::parseAddressList($this->struct->headers['reply-to']);
+    }
+
     function getBody(){
 
         $body='';
@@ -336,6 +340,13 @@ class EmailDataParser {
         $data['mid'] = $parser->getMessageId();
         $data['priorityId'] = $parser->getPriority();
         $data['emailId'] = $emailId;
+
+        if ($replyto = $parser->getReplyTo()) {
+            $replyto = $replyto[0];
+            $data['reply-to'] = $replyto->mailbox.'@'.$replyto->host;
+            if ($replyto->personal)
+                $data['reply-to-name'] = trim($replyto->personal, " \t\n\r\0\x0B\x22");
+        }
 
         if($cfg && $cfg->allowEmailAttachments())
             $data['attachments'] = $parser->getAttachments();


### PR DESCRIPTION
The email filtering feature supports a 'Use Reply-To' feature, but seems to never have been implemented. This patch officially supports using the Reply-To email header as the From header for emails matching the filter.
