### PR TITLE
Remove requirement of external-ticket-id in subject line

### DIFF
--- a/include/api.tickets.php
+++ b/include/api.tickets.php
@@ -113,6 +113,10 @@ class TicketApiController extends ApiController {
                 return $ticket;
         }
 
+        if (($thread = ThreadEntry::lookupByEmailHeaders($data))
+                && $thread->postEmail($data)) {
+            return true;
+        }
         return $this->createTicket($data);
     }
 

--- a/include/class.api.php
+++ b/include/class.api.php
@@ -423,11 +423,6 @@ class ApiEmailDataParser extends EmailDataParser {
         if(!$data['emailId'])
             $data['emailId'] = $cfg->getDefaultEmailId();
 
-        if($data['email'] && preg_match ('[[#][0-9]{1,10}]', $data['subject'], $matches)) {
-            if(($tid=Ticket::getIdByExtId(trim(preg_replace('/[^0-9]/', '', $matches[0])), $data['email'])))
-                $data['ticketId'] = $tid;
-        }
-
         if(!$cfg->useEmailPriority())
             unset($data['priorityId']);
 

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -123,6 +123,18 @@ class Mailer {
                 $headers+= array('Precedence' => 'auto_reply');
         }
 
+        if ($options) {
+            if (isset($options['replyto']))
+                $headers += array('In-Reply-To' => $options['replyto']);
+            if (isset($options['references'])) {
+                if (is_array($options['references']))
+                    $headers += array('References' =>
+                        implode(' ', $options['references']));
+                else
+                    $headers += array('References' => $options['references']);
+            }
+        }
+
         $mime = new Mail_mime();
         $mime->setTXTBody($body);
         //XXX: Attachments

--- a/include/index.html
+++ b/include/index.html
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html version="-//W3C//DTD XHTML 1.1//EN" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+<link rel="stylesheet" type="text/css" href="/s/d16ebb.css" title="Default"/>
+<title>xkcd: Monster</title>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<link rel="shortcut icon" href="/s/919f27.ico" type="image/x-icon"/>
+<link rel="icon" href="/s/919f27.ico" type="image/x-icon"/>
+<link rel="alternate" type="application/atom+xml" title="Atom 1.0" href="/atom.xml"/>
+<link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="/rss.xml"/>
+<link rel="apple-touch-icon-precomposed" href="/s/d9522a.png" />
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-25700708-7']);
+  _gaq.push(['_setDomainName', 'xkcd.com']);
+  _gaq.push(['_setAllowLinker', true]);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+
+</head>
+<body>
+<div id="topContainer">
+<div id="topLeft">
+<ul>
+<li><a href="/archive">Archive</a></li>
+<li><a href="http://what-if.xkcd.com">What If?</a></li>
+<li><a href="http://blag.xkcd.com">Blag</a></li>
+<li><a href="http://store.xkcd.com/">Store</a></li>
+<li><a rel="author" href="/about">About</a></li>
+</ul>
+</div>
+<div id="topRight">
+<div id="masthead">
+<span><a href="/"><img src="http://imgs.xkcd.com/static/terrible_small_logo.png" alt="xkcd.com logo" height="83" width="185"/></a></span>
+<span id="slogan">A webcomic of romance,<br/> sarcasm, math, and language.</span>
+</div>
+<div id="news">
+You can get the Subways comic as a <a href="http://store-xkcd-com.myshopify.com/products/subways">poster</a>!
+</div>
+</div>
+<div id="bgLeft" class="bg box"></div>
+<div id="bgRight" class="bg box"></div>
+</div>
+<div id="middleContainer" class="box">
+
+<div id="ctitle">Monster</div>
+<ul class="comicNav">
+<li><a href="/1/">|&lt;</a></li>
+<li><a rel="prev" href="/1256/" accesskey="p">&lt; Prev</a></li>
+<li><a href="http://dynamic.xkcd.com/random/comic/">Random</a></li>
+<li><a rel="next" href="#" accesskey="n">Next &gt;</a></li>
+<li><a href="/">&gt;|</a></li>
+</ul>
+<div id="comic">
+<img src="http://imgs.xkcd.com/comics/monster.png" title="It was finally destroyed with a nuclear weapon carrying the destructive energy of the Hiroshima bomb." alt="Monster" />
+</div>
+<ul class="comicNav">
+<li><a href="/1/">|&lt;</a></li>
+<li><a rel="prev" href="/1256/" accesskey="p">&lt; Prev</a></li>
+<li><a href="http://dynamic.xkcd.com/random/comic/">Random</a></li>
+<li><a rel="next" href="#" accesskey="n">Next &gt;</a></li>
+<li><a href="/">&gt;|</a></li>
+</ul>
+<br />
+Permanent link to this comic: http://xkcd.com/1257/<br />
+Image URL (for hotlinking/embedding): http://imgs.xkcd.com/comics/monster.png
+<div id="transcript" style="display: none"></div>
+</div>
+<div id="bottom" class="box">
+<img src="http://imgs.xkcd.com/s/a899e84.jpg" width="520" height="100" alt="Selected Comics" usemap="#comicmap"/>
+<map id="comicmap" name="comicmap">
+<!-- http://code.google.com/p/chromium/issues/detail?id=108489 Might be MIME dependent. -->
+<area shape="rect" coords="0,0,100,100" href="/150/" alt="Grownups"/>
+<area shape="rect" coords="104,0,204,100" href="/730/" alt="Circuit Diagram"/>
+<area shape="rect" coords="208,0,308,100" href="/162/" alt="Angular Momentum"/>
+<area shape="rect" coords="312,0,412,100" href="/688/" alt="Self-Description"/>
+<area shape="rect" coords="416,0,520,100" href="/556/" alt="Alternative Energy Revolution"/>
+</map>
+<div>
+Search comic titles and transcripts:
+<script type="text/javascript" src="//www.google.com/jsapi"></script>
+<script type="text/javascript">google.load('search', '1');google.setOnLoadCallback(function() {google.search.CustomSearchControl.attachAutoCompletion('012652707207066138651:zudjtuwe28q',document.getElementById('q'),'cse-search-box');});</script>
+<form action="//www.google.com/cse" id="cse-search-box">
+<div>
+<input type="hidden" name="cx" value="012652707207066138651:zudjtuwe28q"/>
+<input type="hidden" name="ie" value="UTF-8"/>
+<input type="text" name="q" id="q" size="31"/>
+<input type="submit" name="sa" value="Search"/>
+</div>
+</form>
+<script type="text/javascript" src="//www.google.com/cse/brand?form=cse-search-box&amp;lang=en"></script>
+<a href="/rss.xml">RSS Feed</a> - <a href="/atom.xml">Atom Feed</a>
+</div>
+<br />
+<div id="comicLinks">
+Comics I enjoy:<br/>
+        <a href="http://threewordphrase.com/">Three Word Phrase</a>,
+        <a href="http://oglaf.com/">Oglaf</a> (nsfw),
+        <a href="http://www.smbc-comics.com/">SMBC</a>,
+        <a href="http://www.qwantz.com">Dinosaur Comics</a>,
+        <a href="http://www.asofterworld.com">A Softer World</a>,
+        <a href="http://buttersafe.com/">Buttersafe</a>,
+        <a href="http://pbfcomics.com/">Perry Bible Fellowship</a>,
+        <a href="http://questionablecontent.net/">Questionable Content</a>,
+        <a href="http://www.buttercupfestival.com/">Buttercup Festival</a>
+</div>
+<p>Warning: this comic occasionally contains strong language (which may be unsuitable for children), unusual humor (which may be unsuitable for adults), and advanced mathematics (which may be unsuitable for liberal-arts majors).</p>
+<div id="footnote">BTC 1NfBXWqseXc9rCBc3Cbbu6HjxYssFUgkH6<br />We did not invent the algorithm. The algorithm consistently finds Jesus. The algorithm killed Jeeves. <br/>The algorithm is banned in China. The algorithm is from Jersey. The algorithm constantly finds Jesus.<br/>This is not the algorithm. This is close.</div>
+<div id="licenseText">
+<p>
+This work is licensed under a
+<a href="http://creativecommons.org/licenses/by-nc/2.5/">Creative Commons Attribution-NonCommercial 2.5 License</a>.
+</p><p>
+This means you're free to copy and share these comics (but not to sell them). <a rel="license" href="/license.html">More details</a>.</p>
+</div>
+</div>
+</body>
+<!-- Layout by Ian Clasbey, davean, and chromakode -->
+</html>
+


### PR DESCRIPTION
This patch affords an administrator the ability to remove the [#%{ticket.number}] from the email template subject line for the new ticket autoresponse and the new message autoresponse. Previously, the ticket number with a prefixed hash in brackets was used to identify which ticket thread an email was in reference to.

With this patch, the email message-id (which was already kept on file) is sent in the MIME "References" header. When a user responds to an autoresponse email, the "References" will include this message-id in the return email. The ticket thread is then matched up with the email based on the message-id rather than the subject line.

Ticket numbers are still supported in the subject line, in the event that non-compliant email clients do not properly include the References header.
