### PR TITLE
Don't leak private FAQ titles

### DIFF
--- a/include/client/knowledgebase.inc.php
+++ b/include/client/knowledgebase.inc.php
@@ -61,18 +61,18 @@ if($_REQUEST['q'] || $_REQUEST['cid'] || $_REQUEST['topicId']) { //Search.
         .' LEFT JOIN '.FAQ_CATEGORY_TABLE.' cat ON(cat.category_id=faq.category_id) '
         .' LEFT JOIN '.FAQ_TOPIC_TABLE.' ft ON(ft.faq_id=faq.faq_id) '
         .' WHERE faq.ispublished=1 AND cat.ispublic=1';
-    
+
     if($_REQUEST['cid'])
         $sql.=' AND faq.category_id='.db_input($_REQUEST['cid']);
-    
+
     if($_REQUEST['topicId'])
         $sql.=' AND ft.topic_id='.db_input($_REQUEST['topicId']);
 
 
     if($_REQUEST['q']) {
-        $sql.=" AND question LIKE ('%".db_input($_REQUEST['q'],false)."%') 
-                 OR answer LIKE ('%".db_input($_REQUEST['q'],false)."%') 
-                 OR keywords LIKE ('%".db_input($_REQUEST['q'],false)."%')";
+        $sql.=" AND (question LIKE ('%".db_input($_REQUEST['q'],false)."%')
+                 OR answer LIKE ('%".db_input($_REQUEST['q'],false)."%')
+                 OR keywords LIKE ('%".db_input($_REQUEST['q'],false)."%'))";
     }
 
     $sql.=' GROUP BY faq.faq_id';


### PR DESCRIPTION
Fixes #683

Search results on the client interface for knowledgebase articles would previous show hits for the internal (private) knowledgebase articles. The subjects were shown but the articles were not viewable.

This addresses the SQL logic issue causing the private hits to be shown.
