### PR TITLE
Make phone ext optional for XML API

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -317,8 +317,9 @@ class ApiXmlDataParser extends XmlDataParser {
         if (!is_array($current))
             return $current;
         foreach ($current as $key=>&$value) {
-            if ($key == "phone") {
-                $current["phone_ext"] = $value["ext"];  # PHP [like] point
+            if ($key == "phone" && is_array($value)) {
+                if (isset($value['ext']))
+                    $current["phone_ext"] = $value["ext"];  # PHP [like] point
                 $value = $value[":text"];
             } else if ($key == "alert") {
                 $value = (bool)$value;
@@ -339,6 +340,7 @@ class ApiXmlDataParser extends XmlDataParser {
                 $value = $this->fixup($value);
             }
         }
+        unset($value);
 
         return $current;
     }


### PR DESCRIPTION
Previously, the @ext attribute for the phone number field was assumed to be included. An XML payload without the @ext attribute would have been corrupted to include only the first digit of the phone number, which would fail validation.

This patch correctly handles the XML payload without the @ext attribute for the phone number. Subsequently, the <phone_ext> element is now also valid (and optional as well).

Fixes #670
