### PR TITLE
Don't send emails for non-existent table

### DIFF
--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -690,7 +690,7 @@ class Staff {
         //       this user id
         $sql = 'DELETE FROM '.CONFIG_TABLE.' WHERE `namespace`="pwreset"
             AND `value`='.db_input($this->getId());
-        db_query($sql);
+        db_query($sql, false);
         unset($_SESSION['_staff']['reset-token']);
     }
 


### PR DESCRIPTION
When an admin logs in to upgrade to 1.7.1 and further from a version pervious
to 1.7.1, the system will attempt to clear password reset tokens from the
config table, which hasn't been upgraded yet to the namespaced version from
1.7.1

This patch avoids sending an email with the offending SQL statement to the
administrator.
