### PR TITLE
ROOT_DIR should be used to identify filesystem paths

### DIFF
--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -22,7 +22,7 @@ if(!strcasecmp(basename($_SERVER['SCRIPT_NAME']),basename(__FILE__)) || !defined
 #Install flag
 define('OSTINSTALLED',FALSE);
 if(OSTINSTALLED!=TRUE){
-    if(!file_exists(ROOT_PATH.'setup/install.php')) die('Error: Contact system admin.'); //Something is really wrong!
+    if(!file_exists(ROOT_DIR.'setup/install.php')) die('Error: Contact system admin.'); //Something is really wrong!
     //Invoke the installer.
     header('Location: '.ROOT_PATH.'setup/install.php');
     exit;


### PR DESCRIPTION
Historically, ROOT_PATH and ROOT_DIR contained the same value; however, 
ROOT_PATH now points to the URL path where osTicket is installed, whereas 
ROOT_DIR points to the file system location where osTicket is installed.
