### PR TITLE
Use the correct Content-Type header for CAPTCHA

### DIFF
--- a/include/class.captcha.php
+++ b/include/class.captcha.php
@@ -3,7 +3,7 @@
     class.captcha.php
 
     Very basic captcha class.
-    
+
     Peter Rotich <peter@osticket.com>
     Copyright (c)  2006-2013 osTicket
     http://www.osticket.com
@@ -44,7 +44,7 @@ class Captcha {
         $img= imagecreatefrompng($this->bgimg);
         imagestring($img,$this->font, $x, $y,$this->hash,imagecolorallocate($img,0, 0, 0));
 
-        Header ("(captcha-content-type:) image/png");
+        header("Content-Type: image/png");
         imagepng($img);
         imagedestroy($img);
         $_SESSION['captcha'] = md5($this->hash);


### PR DESCRIPTION
Some security inspection appliances and load balancers don't appreciate something in the HTTP headers that is not a valid HTTP header. Furthermore, the browser needs the Content-Type header to identify that the image is not the PHP default of text/html
