### PR TITLE
Define ROOT_PATH in chrooted environments too

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -139,21 +139,17 @@ class Misc {
         return $output;
     }
 
-    function siteBaseUrl() {
-        # Detects Alias-ing
-        $paths = explode('/', $_SERVER['REQUEST_URI']);
-        # Drop the last item -- it will be the php page we're on
-        array_pop($paths);
-        $leading = array();
-        while (count($paths)) {
-            if (in_array($paths[0], array('scp','client')))
-                break;
-            $leading[] = array_shift($paths);
+    /* static */
+    function siteRootPath($main_inc_path) {
+        $root = str_replace('\\', '/', $main_inc_path);
+        $root2 = str_replace('\\','/', $_SERVER['DOCUMENT_ROOT']);
+        $path = '';
+        while (strpos($_SERVER['DOCUMENT_ROOT'], $root) === false) {
+            $lastslash = strrpos($root, '/');
+            $path = substr($root, $lastslash) . $path;
+            $root = substr($root, 0, $lastslash);
         }
-        if (count($leading) > 1)
-            return implode('/', $leading);
-        else
-            return '';
+        return $path;
     }
 
 }

--- a/main.inc.php
+++ b/main.inc.php
@@ -60,13 +60,6 @@
     }
 
     #Set Dir constants
-    $here = substr(realpath(dirname(__file__)),
-        strlen($_SERVER['DOCUMENT_ROOT']));
-    // Determine the path in the URI used as the base of the osTicket
-    // installation
-    if (!defined('ROOT_PATH'))
-        define('ROOT_PATH', str_replace('\\', '/', $here.'/')); //root path. Damn directories
-
     define('ROOT_DIR',str_replace('\\\\', '/', realpath(dirname(__FILE__))).'/'); #Get real path for root dir ---linux and windows
     define('INCLUDE_DIR',ROOT_DIR.'include/'); //Change this if include is moved outside the web path.
     define('PEAR_DIR',INCLUDE_DIR.'pear/');
@@ -74,6 +67,13 @@
 
     define('UPGRADE_DIR', INCLUDE_DIR.'upgrader/');
     define('I18N_DIR', INCLUDE_DIR.'i18n/');
+
+    require(INCLUDE_DIR.'class.misc.php');
+
+    // Determine the path in the URI used as the base of the osTicket
+    // installation
+    if (!defined('ROOT_PATH'))
+        define('ROOT_PATH', Misc::siteRootPath(realpath(dirname(__file__))).'/'); //root path. Damn directories
 
     /*############## Do NOT monkey with anything else beyond this point UNLESS you really know what you are doing ##############*/
 
@@ -117,7 +117,6 @@
     require(INCLUDE_DIR.'class.pagenate.php'); //Pagenate helper!
     require(INCLUDE_DIR.'class.log.php');
     require(INCLUDE_DIR.'class.crypto.php');
-    require(INCLUDE_DIR.'class.misc.php');
     require(INCLUDE_DIR.'class.timezone.php');
     require(INCLUDE_DIR.'class.http.php');
     require(INCLUDE_DIR.'class.signal.php');


### PR DESCRIPTION
Properly detect the ROOT_PATH variable if the HTTP server is chrooted
