### PR TITLE
Provide a fallback ROOT_PATH

### DIFF
--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -141,11 +141,18 @@ class Misc {
 
     /* static */
     function siteRootPath($main_inc_path) {
+        if (!$_SERVER['DOCUMENT_ROOT'])
+            // Probably run from the command-line
+            return './';
         $root = str_replace('\\', '/', $main_inc_path);
         $root2 = str_replace('\\','/', $_SERVER['DOCUMENT_ROOT']);
         $path = '';
         while (strpos($_SERVER['DOCUMENT_ROOT'], $root) === false) {
             $lastslash = strrpos($root, '/');
+            if ($lastslash === false)
+                // Unable to find any commonality between $root and
+                // DOCUMENT_ROOT
+                return './';
             $path = substr($root, $lastslash) . $path;
             $root = substr($root, 0, $lastslash);
         }


### PR DESCRIPTION
If unable to detect the root path, provide a fallback ROOT_PATH setting to `./`. This is likely to happen if run from the commandline (like for crons) or if DOCUMENT_ROOT and the folder of main.inc.php seem to have nothing in common

Fixes #704
