### PR TITLE
Fix cookie domain for localhost

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -130,10 +130,6 @@
     else
         require(INCLUDE_DIR.'mysql.php');
 
-    #Cookies
-    session_set_cookie_params(86400, ROOT_PATH, $_SERVER['HTTP_HOST'],
-        osTicket::is_https());
-
     #CURRENT EXECUTING SCRIPT.
     define('THISPAGE', Misc::currentURL());
     define('THISURI', $_SERVER['REQUEST_URI']);


### PR DESCRIPTION
Web browsers don't appreciate a cookie domain without any dots. This patch detects the originally-requested domain for the request. If the domain does not contain dots (such as 'localhost' or the name of a local server on your network defined in your hosts file), no cookie domain is sent.

The greatest symptom of this issue what the illustrious 'Invalid CSRF token' seen repeatedly on the scp login page. The reason is that the browser was rejecting the cookie from the server.
