### PR TITLE
Allow HTTP auth pass-though

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -719,6 +719,62 @@ class OsticketConfig extends Config {
         return $this->get('upload_dir');
     }
 
+    /**
+     * Returns true if HTTP pass-though authentication is enabled, otherwise false.
+     *
+     * Configuration: allow_http_auth
+     *
+     * @return bool
+     */
+    function allowHttpAuth() {
+        return (int)$this->get('allow_http_auth') === 1;
+    }
+
+    /**
+     * Returns true if users that pass through HTTP authentication should be automatically created, otherwise false.
+     *
+     * Configuration: auto_create_users
+     *
+     * @return bool
+     */
+    function autoCreateUsers() {
+        return (int)$this->get('auto_create_users') === 1;
+    }
+
+    /**
+     * Default domain for users when auto-created.
+     *
+     * Configuration: default_email_domain
+     *
+     * @return string
+     */
+    function defaultEmailDomain() {
+        return $this->get('default_email_domain');
+    }
+
+    /**
+     * Default timezone id.
+     *
+     * Configuration: default_timezone_id
+     *
+     * @return int
+     */
+    function defaultTimezoneId() {
+        return $this->get('default_timezone_id');
+    }
+
+
+    /**
+     * Returns the id of the default group automatically created users should use.
+     *
+     * Configuration: default_group_id
+     *
+     * @return int
+     */
+    function defaultGroupId() {
+        return $this->get('default_group_id');
+    }
+
     function updateSettings($vars, &$errors) {
 
         if(!$vars || $errors)
@@ -800,6 +856,10 @@ class OsticketConfig extends Config {
             'daydatetime_format'=>$vars['daydatetime_format'],
             'default_timezone_id'=>$vars['default_timezone_id'],
             'enable_daylight_saving'=>isset($vars['enable_daylight_saving'])?1:0,
+            'allow_http_auth'=>isset($vars['allow_http_auth'])?1:0,
+            'auto_create_users'=>isset($vars['auto_create_users'])?1:0,
+            'default_group_id'=>$vars['default_group_id'],
+            'default_email_domain'=>$vars['default_email_domain']
         ));
     }
 

--- a/include/staff/firstlogin.php
+++ b/include/staff/firstlogin.php
@@ -1,0 +1,122 @@
+<?php
+if(!$thisstaff) die('Access Denied');
+
+$info=array();
+$info=$staff->getInfo();
+$info['id']=$thisstaff->getId();
+$info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
+?>
+<form action="firstlogin.php" method="post" id="save" autocomplete="off">
+ <?php csrf_token(); ?>
+ <h2>Staff Account</h2>
+ <table class="form_table" width="940" border="0" cellspacing="0" cellpadding="2">
+    <thead>
+        <tr>
+            <th colspan="2">
+                <h4>Update Information</h4>
+                <em><strong>User Information</strong></em>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td width="180" class="required">
+                First Name:
+            </td>
+            <td>
+                <input type="text" size="30" name="firstname" value="<?php echo $info['firstname']; ?>">
+                &nbsp;<span class="error">*&nbsp;<?php echo $errors['firstname']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <td width="180" class="required">
+                Last Name:
+            </td>
+            <td>
+                <input type="text" size="30" name="lastname" value="<?php echo $info['lastname']; ?>">
+                &nbsp;<span class="error">*&nbsp;<?php echo $errors['lastname']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <td width="180" class="required">
+                Email Address:
+            </td>
+            <td>
+                <input type="text" size="30" name="email" value="<?php echo $info['email']; ?>">
+                &nbsp;<span class="error">*&nbsp;<?php echo $errors['email']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <td width="180">
+                Phone Number:
+            </td>
+            <td>
+                <input type="text" size="18" name="phone" value="<?php echo $info['phone']; ?>">
+                &nbsp;<span class="error">&nbsp;<?php echo $errors['phone']; ?></span>
+                Ext <input type="text" size="5" name="phone_ext" value="<?php echo $info['phone_ext']; ?>">
+                &nbsp;<span class="error">&nbsp;<?php echo $errors['phone_ext']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <td width="180">
+                Mobile Number:
+            </td>
+            <td>
+                <input type="text" size="18" name="mobile" value="<?php echo $info['mobile']; ?>">
+                &nbsp;<span class="error">&nbsp;<?php echo $errors['mobile']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <th colspan="2">
+                <em><strong>Staff's Signature</strong>: Optional signature used on outgoing emails. &nbsp;<span class="error">&nbsp;<?php echo $errors['signature']; ?></span></em>
+            </th>
+        </tr>
+        <tr>
+            <td colspan=2>
+                <textarea name="signature" cols="21" rows="5" style="width: 60%;"><?php echo $info['signature']; ?></textarea>
+                <br><em>Signature is made available as a choice, on ticket reply.</em>
+            </td>
+        </tr>
+        <tr>
+            <th colspan="2">
+                <em><strong>Account Status & Settings</strong>: Dept. and assigned group controls access permissions.</em>
+            </th>
+        </tr>
+        <tr>
+            <td width="180" class="required">
+                Staff's Time Zone:
+            </td>
+            <td>
+                <select name="timezone_id" id="timezone_id">
+                    <option value="0">&mdash; Select Time Zone &mdash;</option>
+                    <?php
+                    $sql='SELECT id, offset,timezone FROM '.TIMEZONE_TABLE.' ORDER BY id';
+                    if(($res=db_query($sql)) && db_num_rows($res)){
+                        while(list($id,$offset, $tz)=db_fetch_row($res)){
+                            $sel=($info['timezone_id']==$id)?'selected="selected"':'';
+                            echo sprintf('<option value="%d" %s>GMT %s - %s</option>',$id,$sel,$offset,$tz);
+                        }
+                    }
+                    ?>
+                </select>
+                &nbsp;<span class="error">*&nbsp;<?php echo $errors['timezone_id']; ?></span>
+            </td>
+        </tr>
+        <tr>
+            <td width="180">
+               Daylight Saving:
+            </td>
+            <td>
+                <input type="checkbox" name="daylight_saving" value="1" <?php echo $info['daylight_saving']?'checked="checked"':''; ?>>
+                Observe daylight saving
+                <em>(Current Time: <strong><?php echo Format::date($cfg->getDateTimeFormat(),Misc::gmtime(),$info['tz_offset'],$info['daylight_saving']); ?></strong>)</em>
+            </td>
+        </tr>
+    </tbody>
+</table>
+<p style="padding-left:250px;">
+    <input type="submit" name="submit" value="Save Changes">
+    <input type="reset"  name="reset"  value="Reset">
+    <input type="button" name="cancel" value="Cancel" onclick='window.location.href="staff.php"'>
+</p>
+</form>

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -41,7 +41,7 @@
     ?>
     <div id="header">
         <a href="index.php" id="logo">osTicket - Customer Support System</a>
-        <p id="info">Howdy, <strong><?php echo $thisstaff->getUserName(); ?></strong>
+        <p id="info">Howdy, <strong><?php echo $thisstaff->getName(); ?></strong>
            <?php
             if($thisstaff->isAdmin() && !defined('ADMINPAGE')) { ?>
             | <a href="admin.php">Admin Panel</a>
@@ -49,7 +49,9 @@
             | <a href="index.php">Staff Panel</a>
             <?php } ?>
             | <a href="profile.php">My Preferences</a>
+            <?php if (!isset($_SERVER['AUTH_TYPE'])) { ?>
             | <a href="logout.php?auth=<?php echo $ost->getLinkToken(); ?>">Log Out</a>
+            <?php } ?>
         </p>
     </div>
     <ul id="nav">

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -117,7 +117,7 @@ $gmtime = Misc::gmtime();
                 <em><b>Authentication Settings</b></em>
             </th>
         </tr>
-        <tr><td>Password Change Policy:</th>
+        <tr><td>Password Change Policy:</td>
             <td>
                 <select name="passwd_reset_period">
                    <option value="0"> &mdash; None &mdash;</option>
@@ -131,14 +131,14 @@ $gmtime = Misc::gmtime();
                 &nbsp;<font class="error">&nbsp;<?php echo $errors['passwd_reset_period']; ?></font>
             </td>
         </tr>
-        <tr><td>Allow Password Resets:</th>
+        <tr><td>Allow Password Resets:</td>
             <td>
               <input type="checkbox" name="allow_pw_reset" <?php echo $config['allow_pw_reset']?'checked="checked"':''; ?>>
               <em>Enables the <u>Forgot my password</u> link on the staff
               control panel</em>
             </td>
         </tr>
-        <tr><td>Password Reset Window:</th>
+        <tr><td>Password Reset Window:</td>
             <td>
               <input type="text" name="pw_reset_window" size="6" value="<?php
                     echo $config['pw_reset_window']; ?>">
@@ -203,6 +203,46 @@ $gmtime = Misc::gmtime();
               <em>(binds staff session to originating IP address upon login)</em>
             </td>
         </tr>
+        <tr>
+            <th colspan="2">
+                <em><b>HTTP Authentication</b>
+            </th>
+        </tr>
+        <tr><td>Enabled:</td>
+            <td>
+                <input type="checkbox" name="allow_http_auth" <?php echo $config['allow_http_auth']?'checked="checked"':''; ?>>
+                <em>Enables HTTP pass-though authentication</em>
+            </td>
+        </tr>
+        <tr><td>Auto Create Users:</td>
+            <td>
+                <input type="checkbox" name="auto_create_users" <?php echo $config['auto_create_users']?'checked="checked"':''; ?>>
+                <em>Automatically creates users in osTicket if they do not exist</em>
+            </td>
+        </tr>
+        <tr><td>Default Group:</td>
+            <td>
+                <select name="default_group_id" id="group_id">
+                    <option value="0">&mdash; Select Group &mdash;</option>
+                    <?php
+                    $sql='SELECT group_id, group_name, group_enabled as isactive FROM '.GROUP_TABLE.' ORDER BY group_name';
+                    if(($res=db_query($sql)) && db_num_rows($res)){
+                        while(list($id,$name,$isactive)=db_fetch_row($res)){
+                            $sel=($config['default_group_id']==$id)?'selected="selected"':'';
+                            echo sprintf('<option value="%d" %s>%s %s</option>',$id,$sel,$name,($isactive?'':' (Disabled)'));
+                        }
+                    }
+                    ?>
+                </select>
+            </td>
+        </tr>
+        <tr><td>Default Email Domain:</td>
+            <td>
+                <input type="text" name="default_email_domain" value="<?php echo $config['default_email_domain']; ?>">
+                &nbsp;<em>example.net</em>
+            </td>
+        </tr>
+
         <tr>
             <th colspan="2">
                 <em><b>Date and Time Options</b>: Please refer to <a href="http://php.net/date" target="_blank">PHP Manual</a> for supported parameters.</em>

--- a/scp/firstlogin.php
+++ b/scp/firstlogin.php
@@ -1,0 +1,44 @@
+<?php
+/*********************************************************************
+    staff.php
+
+    Evertything about staff members.
+
+    Peter Rotich <peter@osticket.com>
+    Copyright (c)  2006-2013 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+require('staff.inc.php');
+
+$staff = $thisstaff;
+
+if($_POST){
+    $vars = $_POST;
+    $vars['id'] = $staff->getId();
+    $vars['username'] = $staff->getUserName();
+    $vars['dept_id'] = $staff->getDeptId();
+    $vars['group_id'] = $staff->getGroupId();
+    $vars['isadmin'] = '0';
+    $vars['isactive'] = '1';
+
+    if($staff->update($vars,$errors)){
+        $msg='Staff updated successfully';
+    }elseif(!$errors['err']){
+        $errors['err']='Unable to update staff. Correct any error(s) below and try again!';
+    }
+}
+
+$page='firstlogin.php';
+//if($staff || ($_REQUEST['a'] && !strcasecmp($_REQUEST['a'],'add')))
+//    $page='staff.inc.php';
+
+$nav->setTabActive('staff');
+require(STAFFINC_DIR.'header.inc.php');
+require(STAFFINC_DIR.$page);
+include(STAFFINC_DIR.'footer.inc.php');
+?>

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -57,6 +57,19 @@ if(!function_exists('staffLoginPage')) { //Ajax interface can pre-declare the fu
 }
 
 $thisstaff = new StaffSession($_SESSION['_staff']['userID']); //Set staff object.
+
+if (!$thisstaff->isValid() && isset($_SERVER['AUTH_TYPE'])) {
+    $thisstaff = Staff::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'], $errors);
+
+    if ($thisstaff !== false) {
+        $thisstaff->session->session_id = session_id();
+        $thisstaff->refreshSession();
+    } else {
+        //The credentials provided via HTTP auth don't match whats in the database. Reset the object back to a "valid" one.
+        $thisstaff = new StaffSession($_SESSION['_staff']['userID']); //Set staff object.
+    }
+}
+
 //1) is the user Logged in for real && is staff.
 if(!$thisstaff->getId() || !$thisstaff->isValid()){
     if (isset($_SESSION['_staff']['auth']['msg'])) {
@@ -71,6 +84,7 @@ if(!$thisstaff->getId() || !$thisstaff->isValid()){
     staffLoginPage($msg);
     exit;
 }
+
 //2) if not super admin..check system status and group status
 if(!$thisstaff->isAdmin()) {
     //Check for disabled staff or group!


### PR DESCRIPTION
Allow HTTP auth pass-through. Useful where you have a paranoid systems admin who only trusts HTTP auth to protect the site. Removes the logout link if the user authenticated with HTTP auth.

Also fixes what I presume was a minor oversight where "Howdy, username" was displayed instead of the users full name.
