### PR TITLE
Forbid message loops for alert messages

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -426,11 +426,10 @@ class MailFetcher {
 
         if (($thread = ThreadEntry::lookupByEmailHeaders($vars))
                 && ($message = $thread->postEmail($vars))) {
-            if ($message === true)
+            if (!$message instanceof ThreadEntry)
                 // Email has been processed previously
-                return true;
-            elseif ($message)
-                $ticket = $message->getTicket();
+                return $message;
+            $ticket = $message->getTicket();
         } elseif (($ticket=Ticket::create($vars, $errors, 'Email'))) {
             $message = $ticket->getLastMessage();
         } else {

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -519,6 +519,7 @@ Class ThreadEntry {
 
         $vars = array(
             'mid' =>    $mailinfo['mid'],
+            'header' => $mailinfo['header'],
             'ticketId' => $ticket->getId(),
             'poster' => $mailinfo['name'],
             'origin' => 'Email',
@@ -542,6 +543,10 @@ Class ThreadEntry {
             $errors = array();
             $vars['note'] = $body;
             return $ticket->postNote($vars, $errors, $poster);
+        }
+        elseif (Email::lookupByEmail($mailinfo['email'])) {
+            // Don't process the email -- it came FROM this system
+            return true;
         }
         // TODO: Consider security constraints
         else {


### PR DESCRIPTION
If an alert message manages to loop back into the ticketing system, refuse
posting to the ticket thread. Technically, the message should be marked as
an auto-response message; however, auto-response messages should usually be
allowed to be appended to the ticket thread.

This patch will check if the From email header cites an email address that
is a system email address (visible in the Emails section of the Admin
Panel). If it is, the email is completely ignored.
