### PR TITLE
Fixes cookie domain specification

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -35,7 +35,9 @@ class osTicketSession {
         if (isset($_SERVER['HTTP_HOST'])
                 && strpos($_SERVER['HTTP_HOST'], '.') !== false
                 && !Validator::is_ip($_SERVER['HTTP_HOST']))
-            $domain = $_SERVER['HTTP_HOST'];
+            // Remote port specification, as it will make an invalid domain
+            list($domain) = explode(':', $_SERVER['HTTP_HOST']);
+
         session_set_cookie_params(86400, ROOT_PATH, $domain,
             osTicket::is_https());
 


### PR DESCRIPTION
if the domain given in HTTP_HOST variable happens to have a port
specification. Technically, the port specification should not be included in
the domain spec given in the cookie.

(And for the record, that makes no sense to me, seeing as a cookie would
otherwise be valid for all servers on any ports at a particular domain).
