### PR TITLE
Fix ROOT_PATH detection on Windows

### DIFF
--- a/client.inc.php
+++ b/client.inc.php
@@ -15,7 +15,7 @@
 **********************************************************************/
 if(!strcasecmp(basename($_SERVER['SCRIPT_NAME']),basename(__FILE__))) die('kwaheri rafiki!');
 
-$thisdir=str_replace('\\\\', '/', realpath(dirname(__FILE__))).'/'; 
+$thisdir=str_replace('\\', '/', realpath(dirname(__FILE__))).'/';
 if(!file_exists($thisdir.'main.inc.php')) die('Fatal Error.');
 
 require_once($thisdir.'main.inc.php');

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -386,7 +386,8 @@ class osTicket {
          * What's left is the ROOT_PATH.
          */
         $frame = array_pop(debug_backtrace(false));
-        $path = substr($frame['file'], strlen(ROOT_DIR));
+        $file = str_replace('\\','/', $frame['file']);
+        $path = substr($file, strlen(ROOT_DIR));
         if($path && ($pos=strpos($_SERVER['SCRIPT_NAME'], $path))!==false)
             return substr($_SERVER['SCRIPT_NAME'], 0, $pos);
 

--- a/include/class.pdf.php
+++ b/include/class.pdf.php
@@ -14,7 +14,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 
-define('THIS_DIR', str_replace('\\\\', '/', realpath(dirname(__FILE__))) . '/'); //Include path..
+define('THIS_DIR', str_replace('\\', '/', realpath(dirname(__FILE__))) . '/'); //Include path..
 define('FPDF_DIR', THIS_DIR . 'fpdf/');
 define('FPDF_FONTPATH', FPDF_DIR . 'font/'); //fonts directory.
 require (FPDF_DIR . 'fpdf.php');

--- a/main.inc.php
+++ b/main.inc.php
@@ -60,7 +60,7 @@
     }
 
     #Set Dir constants
-    define('ROOT_DIR',str_replace('\\\\', '/', realpath(dirname(__FILE__))).'/'); #Get real path for root dir ---linux and windows
+    define('ROOT_DIR',str_replace('\\', '/', realpath(dirname(__FILE__))).'/'); #Get real path for root dir ---linux and windows
     define('INCLUDE_DIR',ROOT_DIR.'include/'); //Change this if include is moved outside the web path.
     define('PEAR_DIR',INCLUDE_DIR.'pear/');
     define('SETUP_DIR',INCLUDE_DIR.'setup/');


### PR DESCRIPTION
Also converts ROOT_DIR detection to always use forward slashes. And it fixes
the removal of the leading double-backslash on Windows UNC names (fixes #649)
