### PR TITLE
Fix email address comparison issue

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -533,7 +533,7 @@ Class ThreadEntry {
         // Disambiguate if the user happens also to be a staff member of the
         // system. The current ticket owner should _always_ post messages
         // instead of notes or responses
-        if ($mailinfo['email'] == $ticket->getEmail()) {
+        if (strcasecmp($mailinfo['email'], $ticket->getEmail()) == 0) {
             $vars['message'] = $body;
             return $ticket->postMessage($vars, 'Email');
         }


### PR DESCRIPTION
When comparing the From address of incoming email. If the ticket owner sent
an email back into the system and the email address did not match exactly,
case-wise, the email would not be considered from the ticket owner.
