### PR TITLE
Last mile for test failures

### DIFF
--- a/setup/test/tests/stubs.php
+++ b/setup/test/tests/stubs.php
@@ -1,0 +1,15 @@
+<?php
+
+class mysqli {
+
+    function query() {}
+    function real_escape_string() {}
+    function fetch_row() {}
+
+}
+
+class ReflectionClass {
+    function getMethods() {}
+}
+
+?>


### PR DESCRIPTION
Add stubs.php to include stub classes for built-in PHP classes used throughout the code. This will allow the testing suite to verify that a method exists, albeit not in our codebase
