### PR TITLE
Fix 1.6-* upgrade to 1.7.1

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -25,7 +25,12 @@ class osTicketSession {
         if(!$this->ttl)
             $this->ttl=SESSION_TTL;
 
-        if (defined('DISABLE_SESSION') || OsticketConfig::getDBVersion())
+        session_name('OSTSESSID');
+
+        if (OsticketConfig::getDBVersion())
+            return session_start();
+
+        elseif (defined('DISABLE_SESSION'))
             return;
 
         # Cookies
@@ -54,7 +59,6 @@ class osTicketSession {
         register_shutdown_function('session_write_close');
 
         //Start the session.
-        session_name('OSTSESSID');
         session_start();
     }
 


### PR DESCRIPTION
8e72e521d48ca04fd8db7d05318e2c55b9b2d278 (v1.7.1.2+) introduced a bug where osTicket version 1.6 would not send a cookie (by calling PHP session_start()) for the login page. Therefore, after unpacking the 1.7.1 source code, an upgrade would not be possible, because a login would never be processed correctly.
