### PR TITLE
Accept attachments from email messages

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -528,6 +528,9 @@ Class ThreadEntry {
             'reply_to' => $this,
         );
 
+        if (isset($mailinfo['attachments']))
+            $vars['attachments'] = $mailinfo['attachments'];
+
         $body = $mailinfo['message'];
 
         // Disambiguate if the user happens also to be a staff member of the


### PR DESCRIPTION
if the References or In-Reply-To header matches in a way that continues a ticket's thread, include the attachments in the thread if allowed by the system settings.
