### PR TITLE
Disambiguate version string when running off of git

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -71,7 +71,7 @@
     /*############## Do NOT monkey with anything else beyond this point UNLESS you really know what you are doing ##############*/
 
     #Current version && schema signature (Changes from version to version)
-    define('THIS_VERSION','1.7.0+'); //Shown on admin panel
+    define('THIS_VERSION','1.7-git'); //Shown on admin panel
 
 
     require(INCLUDE_DIR.'class.osticket.php');

--- a/setup/setup.inc.php
+++ b/setup/setup.inc.php
@@ -15,7 +15,7 @@
 **********************************************************************/
 
 #This  version - changed on every release
-define('THIS_VERSION', '1.7.0+');
+define('THIS_VERSION', '1.7-git');
 
 #inits - error reporting.
 $error_reporting = E_ALL & ~E_NOTICE;


### PR DESCRIPTION
If a user is running off of the develop branch, disambiguate what the version they are running.
