### PR TITLE
Expose fail count to shell environment

### DIFF
--- a/setup/cli/package.php
+++ b/setup/cli/package.php
@@ -17,6 +17,10 @@ function get_osticket_root_path() {
     return realpath($start);
 }
 
+function run_tests($root) {
+    return (require "$root/setup/test/run-tests.php");
+}
+
 # Check PHP syntax across all php files
 function glob_recursive($pattern, $flags = 0) {
     $files = glob($pattern, $flags);
@@ -63,6 +67,10 @@ function package($pattern, $destination, $recurse=false, $exclude=false) {
         }
     }
 }
+
+# Run tests before continuing
+if (run_tests($root) > 0)
+    die("Regression tests failed. Cowardly refusing to package\n");
 
 # Create the stage folder for the install files
 if (!is_dir($stage_path))

--- a/setup/test/tests/class.test.php
+++ b/setup/test/tests/class.test.php
@@ -10,6 +10,7 @@ class Test {
         '/include/PasswordHash.php',
         '/include/pear/',
         '/include/Spyc.php',
+        '/setup/cli/stage/',
     );
 
     function Test() {


### PR DESCRIPTION
Also, run the tests in the packager. The packager will automatically run the regression test suite prior to packaging a release. The package will not build if there is at least one fail from the regression tests.
