### PR TITLE
Use base64 encoding for text version of emails

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -150,7 +150,7 @@ class Mailer {
         //Desired encodings...
         $encodings=array(
                 'head_encoding' => 'quoted-printable',
-                'text_encoding' => 'quoted-printable',
+                'text_encoding' => 'base64',
                 'html_encoding' => 'base64',
                 'html_charset'  => 'utf-8',
                 'text_charset'  => 'utf-8',


### PR DESCRIPTION
Some mail clients and mail brokers do not properly handle quoted-printable encoding, used in osTicket outgoing emails. Oddly, the end mail clients render the email with trailing equal signs (=) at the end of every line, where it was added due to QP encoding.

References:
http://www.osticket.com/forums/forum/osticket-1-7-latest-release/troubleshooting-and-problems-aa/10708-solved-microsoft-exchange-internet-mail-lines-end-with
RFC 2045 section 6.7, http://www.ietf.org/rfc/rfc2045.txt
