### PR TITLE
Support incorrectly labeled us-ascii charsets

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -43,10 +43,10 @@ class Format {
 
         // Cleanup - incorrect, bogus, or ambiguous charsets
         if($charset && in_array(strtolower(trim($charset)),
-                array('default','x-user-defined','iso')))
+                array('default','x-user-defined','iso','us-ascii')))
             $charset = 'ISO-8859-1';
 
-        if (strcasecmp($charset, $encoding) === 0)
+        if ($charset && strcasecmp($charset, $encoding) === 0)
             return $text;
 
         $original = $text;

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -304,12 +304,16 @@ class MailFetcher {
                     $text=$this->decode($text, $struct->encoding);
 
                 $charset=null;
-                if($encoding) { //Convert text to desired mime encoding...
-                    if($struct->ifparameters) {
-                        if(!strcasecmp($struct->parameters[0]->attribute,'CHARSET') && strcasecmp($struct->parameters[0]->value,'US-ASCII'))
-                            $charset=trim($struct->parameters[0]->value);
+                if ($encoding) { //Convert text to desired mime encoding...
+                    if ($struct->ifparameters && $struct->parameters) {
+                        foreach ($struct->parameters as $p) {
+                            if (!strcasecmp($p->attribute, 'charset')) {
+                                $charset = trim($p->value);
+                                break;
+                            }
+                        }
                     }
-                    $text=$this->mime_encode($text, $charset, $encoding);
+                    $text = $this->mime_encode($text, $charset, $encoding);
                 }
                 return $text;
             }

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -177,8 +177,9 @@ class Mail_Parse {
             if($ctype && strcasecmp($ctype,$ctypepart)==0) {
                 $content = $struct->body;
                 //Encode to desired encoding - ONLY if charset is known??
-                if(isset($struct->ctype_parameters['charset']) && strcasecmp($struct->ctype_parameters['charset'], $this->charset))
-                    $content = Format::encode($content, $struct->ctype_parameters['charset'], $this->charset);
+                if (isset($struct->ctype_parameters['charset']))
+                    $content = Format::encode($content,
+                        $struct->ctype_parameters['charset'], $this->charset);
 
                 return $content;
             }


### PR DESCRIPTION
Some email clients (names omitted to protect the innocent) advertise the encoding as us-ascii when iso-8859-1 was really implied. This patch allows the two charsets to be interchangable.
