### PR TITLE
Support non-standard port numbers for MySQLi

### DIFF
--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -38,9 +38,19 @@ function db_connect($host, $user, $passwd, $options = array()) {
     elseif(!$passwd)
         return NULL;
 
-    //Connectr
+    $port = ini_get("mysqli.default_port");
+    if (strpos($host, ':') !== false) {
+        list($host, $port) = explode(':', $host);
+        // PHP may not honor the port number if connecting to 'localhost'
+        if (!strcasecmp($host, 'localhost'))
+            // XXX: Looks like PHP gethostbyname() is IPv4 only
+            $host = gethostbyname($host);
+        $port = (int) $port;
+    }
+
+    // Connect
     $start = microtime(true);
-    if(!@$__db->real_connect($host, $user, $passwd)) # nolint
+    if (!@$__db->real_connect($host, $user, $passwd, null, $port)) # nolint
         return NULL;
 
     //Select the database, if any.

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -79,6 +79,13 @@ class Installer extends SetupWizard {
         if(!$this->errors['username'] && in_array(strtolower($vars['username']),array('admin','admins','username','osticket')))
             $this->errors['username']='Bad username';
 
+        // Support port number specified in the hostname with a colon (:)
+        list($host, $port) = explode(':', $vars['dbhost']);
+        if ($port && (!is_numeric($port) || !((int)$port)))
+            $this->errors['db'] = 'Database port number must be a number';
+        elseif ($port && ($port < 1 || $port > 65535))
+            $this->errors['db'] = 'Invalid database port number';
+
         //MYSQL: Connect to the DB and check the version & database (create database if it doesn't exist!)
         if(!$this->errors) {
             if(!db_connect($vars['dbhost'],$vars['dbuser'],$vars['dbpass']))

--- a/setup/inc/footer.inc.php
+++ b/setup/inc/footer.inc.php
@@ -2,6 +2,6 @@
             <div class="clear"></div>
         </div> <!-- content -->
     </div> <!-- wizard -->
-    <div id="footer" class="centered">Copyright &copy; 2012 <a target="_blank" href="http://osticket.com">osTicket.com</a></div>
+    <div id="footer" class="centered">Copyright &copy; 2013 <a target="_blank" href="http://osticket.com">osTicket.com</a></div>
 </body>
 </html>

--- a/setup/tips.html
+++ b/setup/tips.html
@@ -36,8 +36,14 @@
 </div>
 <div id="t10">
 <b>MySQL Hostname</b>
-<p>Most hosts use 'localhost' for local database hostname. Check with your host if localhost fails. Default port set in php.ini is assumed.</p>
-</div>
+<p>
+Most hosts use 'localhost' for local database hostname. Check with your
+host if localhost fails.
+</p>
+<p>
+Default port set in php.ini is assumed. A non-standard port number can be
+specified as <code>hostname:port</code>
+</p>
 <div id="t11">
 <b>MySQL Database</b>
 <p>Name of the database osTicket will use.</p>


### PR DESCRIPTION
Validate port during installation

Add help information about the non-standard port number to the popup tips in the install screen.

Support MySQL 'localhost' connections using a non-standard port number. Ordinarily, MySQL will ignore the port setting on *nix systems if the host is specified as 'localhost'

Implements/Fixes #769
