### PR TITLE
Reduce cost of deleting orphaned files

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -328,15 +328,12 @@ class AttachmentFile {
     /* static */ function deleteOrphans() {
 
         $sql = 'DELETE FROM '.FILE_TABLE.' WHERE id NOT IN ('
-                # DISTINCT implies sort and may not be necessary
-                .'SELECT DISTINCT(file_id) FROM ('
-                    .'SELECT file_id FROM '.TICKET_ATTACHMENT_TABLE
-                    .' UNION ALL '
-                    .'SELECT file_id FROM '.CANNED_ATTACHMENT_TABLE
-                    .' UNION ALL '
-                    .'SELECT file_id FROM '.FAQ_ATTACHMENT_TABLE
-                .') still_loved'
-            .') AND `ft` = "T"';
+                .'SELECT file_id FROM '.TICKET_ATTACHMENT_TABLE
+                .' UNION '
+                .'SELECT file_id FROM '.CANNED_ATTACHMENT_TABLE
+                .' UNION '
+                .'SELECT file_id FROM '.FAQ_ATTACHMENT_TABLE
+            .") AND `ft` = 'T'";
 
         db_query($sql);
 


### PR DESCRIPTION
Previous explain included a nested sub-select, which exponentially increased the count of the rows to be examined. This patch eliminates one layer of nesting on the sub-select and dramatically increases the performance finding orphaned files.

Fixes #773

References:
http://www.osticket.com/forums/forum/osticket-1-7-latest-release/troubleshooting-and-problems-aa/9446-version-1-7-much-slower-than-1-6
