### PR TITLE
Better email headers for In-Reply-To and References

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -124,9 +124,9 @@ class Mailer {
         }
 
         if ($options) {
-            if (isset($options['replyto']))
+            if (isset($options['replyto']) && $options['replyto'])
                 $headers += array('In-Reply-To' => $options['replyto']);
-            if (isset($options['references'])) {
+            if (isset($options['references']) && $options['references']) {
                 if (is_array($options['references']))
                     $headers += array('References' =>
                         implode(' ', $options['references']));

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -124,8 +124,8 @@ class Mailer {
         }
 
         if ($options) {
-            if (isset($options['replyto']) && $options['replyto'])
-                $headers += array('In-Reply-To' => $options['replyto']);
+            if (isset($options['inreplyto']) && $options['inreplyto'])
+                $headers += array('In-Reply-To' => $options['inreplyto']);
             if (isset($options['references']) && $options['references']) {
                 if (is_array($options['references']))
                     $headers += array('References' =>

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -86,7 +86,7 @@ class Mail_Parse {
             if (substr($headers[$i], 0, 1) == " ") {
                 # Continuation from previous header (runon to next line)
                 $j=$i-1; while (!isset($headers[$j]) && $j>0) $j--;
-                $headers[$j] .= "\n".ltrim($headers[$i]);
+                $headers[$j] .= " ".ltrim($headers[$i]);
                 unset($headers[$i]);
             } elseif (strlen($headers[$i]) == 0) {
                 unset($headers[$i]);

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -334,6 +334,25 @@ Class ThreadEntry {
         return $this->ht['email_mid'];
     }
 
+    function getEmailHeaders() {
+        require_once(INCLUDE_DIR.'class.mailparse.php');
+
+        $sql = 'SELECT headers FROM '.TICKET_EMAIL_INFO_TABLE
+            .' WHERE message_id='.$this->getId();
+        $headers = db_result(db_query($sql));
+        return Mail_Parse::splitHeaders($headers);
+    }
+
+    function getEmailReferences() {
+        if (!isset($this->_references)) {
+            $this->_references = $this->getEmailMessageId();
+            $headers = self::getEmailHeaders();
+            if (isset($headers['References']))
+                $this->_references .= " ".$headers['References'];
+        }
+        return $this->_references;
+    }
+
     function getTicket() {
 
         if(!$this->ticket && $this->getTicketId())

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -738,7 +738,7 @@ class Ticket {
             $email =$cfg->getDefaultEmail();
 
         $options = array(
-            'replyto'=>$message->getEmailMessageId(),
+            'inreplyto'=>$message->getEmailMessageId(),
             'references'=>$message->getEmailReferences());
 
         //Send auto response - if enabled.
@@ -889,7 +889,7 @@ class Ticket {
             if (!$message)
                 $message = $this->getLastMessage();
             $options = array(
-                'replyto'=>$message->getEmailMessageId(),
+                'inreplyto'=>$message->getEmailMessageId(),
                 'references'=>$message->getEmailReferences());
             $email->sendAutoReply($this->getEmail(), $msg['subj'], $msg['body'],
                 null, $options);
@@ -950,7 +950,7 @@ class Ticket {
             //Send the alerts.
             $sentlist=array();
             $options = array(
-                'replyto'=>$note->getEmailMessageId(),
+                'inreplyto'=>$note->getEmailMessageId(),
                 'references'=>$note->getEmailReferences());
             foreach( $recipients as $k=>$staff) {
                 if(!is_object($staff) || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
@@ -1203,7 +1203,7 @@ class Ticket {
 
             $sentlist=array();
             $options = array(
-                'replyto'=>$note->getEmailMessageId(),
+                'inreplyto'=>$note->getEmailMessageId(),
                 'references'=>$note->getEmailReferences());
             foreach( $recipients as $k=>$staff) {
                 if(!is_object($staff) || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
@@ -1355,7 +1355,7 @@ class Ticket {
 
             $sentlist=array(); //I know it sucks...but..it works.
             $options = array(
-                'replyto'=>$message->getEmailMessageId(),
+                'inreplyto'=>$message->getEmailMessageId(),
                 'references'=>$message->getEmailReferences());
             foreach( $recipients as $k=>$staff) {
                 if(!$staff || !$staff->getEmail() || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
@@ -1415,7 +1415,7 @@ class Ticket {
 
             $attachments =($cfg->emailAttachments() && $files)?$response->getAttachments():array();
             $options = array(
-                'replyto'=>$response->getEmailMessageId(),
+                'inreplyto'=>$response->getEmailMessageId(),
                 'references'=>$response->getEmailReferences());
             $email->sendAutoReply($this->getEmail(), $msg['subj'], $msg['body'], $attachments,
                 $options);
@@ -1474,7 +1474,7 @@ class Ticket {
             //Set attachments if emailing.
             $attachments = $cfg->emailAttachments()?$response->getAttachments():array();
             $options = array(
-                'replyto' => $response->getEmailMessageId(),
+                'inreplyto' => $response->getEmailMessageId(),
                 'references' => $response->getEmailReferences());
             //TODO: setup  5 param (options... e.g mid trackable on replies)
             $email->send($this->getEmail(), $msg['subj'], $msg['body'], $attachments,
@@ -1588,7 +1588,7 @@ class Ticket {
 
             $attachments = $note->getAttachments();
             $options = array(
-                'replyto'=>$note->getEmailMessageId(),
+                'inreplyto'=>$note->getEmailMessageId(),
                 'references'=>$note->getEmailReferences());
             $sentlist=array();
             foreach( $recipients as $k=>$staff) {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -737,7 +737,9 @@ class Ticket {
         if(!$dept || !($email=$dept->getAutoRespEmail()))
             $email =$cfg->getDefaultEmail();
 
-        $options = array('references'=>$message->getEmailMessageId());
+        $options = array(
+            'replyto'=>$message->getEmailMessageId(),
+            'references'=>$message->getEmailReferences());
 
         //Send auto response - if enabled.
         if($autorespond && $email && $cfg->autoRespONNewTicket()
@@ -886,7 +888,9 @@ class Ticket {
 
             if (!$message)
                 $message = $this->getLastMessage();
-            $options = array('references' => $message->getEmailMessageId());
+            $options = array(
+                'replyto'=>$message->getEmailMessageId(),
+                'references'=>$message->getEmailReferences());
             $email->sendAutoReply($this->getEmail(), $msg['subj'], $msg['body'],
                 null, $options);
         }
@@ -945,7 +949,9 @@ class Ticket {
 
             //Send the alerts.
             $sentlist=array();
-            $options = array('references' => $note->getEmailMessageId());
+            $options = array(
+                'replyto'=>$note->getEmailMessageId(),
+                'references'=>$note->getEmailReferences());
             foreach( $recipients as $k=>$staff) {
                 if(!is_object($staff) || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
                 $alert = str_replace('%{recipient}', $staff->getFirstName(), $msg['body']);
@@ -1196,7 +1202,9 @@ class Ticket {
                 $recipients[]= $manager;
 
             $sentlist=array();
-            $options = array('references' => $note->getEmailMessageId());
+            $options = array(
+                'replyto'=>$note->getEmailMessageId(),
+                'references'=>$note->getEmailReferences());
             foreach( $recipients as $k=>$staff) {
                 if(!is_object($staff) || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
                 $alert = str_replace('%{recipient}', $staff->getFirstName(), $msg['body']);
@@ -1346,7 +1354,9 @@ class Ticket {
                 $recipients[]=$manager;
 
             $sentlist=array(); //I know it sucks...but..it works.
-            $options = array('references'=>$message->getEmailMessageId());
+            $options = array(
+                'replyto'=>$message->getEmailMessageId(),
+                'references'=>$message->getEmailReferences());
             foreach( $recipients as $k=>$staff) {
                 if(!$staff || !$staff->getEmail() || !$staff->isAvailable() || in_array($staff->getEmail(), $sentlist)) continue;
                 $alert = str_replace('%{recipient}', $staff->getFirstName(), $msg['body']);
@@ -1404,7 +1414,9 @@ class Ticket {
                 $msg['body'] ="\n$tag\n\n".$msg['body'];
 
             $attachments =($cfg->emailAttachments() && $files)?$response->getAttachments():array();
-            $options = array('references' => $response->getEmailMessageId());
+            $options = array(
+                'replyto'=>$response->getEmailMessageId(),
+                'references'=>$response->getEmailReferences());
             $email->sendAutoReply($this->getEmail(), $msg['subj'], $msg['body'], $attachments,
                 $options);
         }
@@ -1461,7 +1473,9 @@ class Ticket {
 
             //Set attachments if emailing.
             $attachments = $cfg->emailAttachments()?$response->getAttachments():array();
-            $options = array('references' => $response->getEmailMessageId());
+            $options = array(
+                'replyto' => $response->getEmailMessageId(),
+                'references' => $response->getEmailReferences());
             //TODO: setup  5 param (options... e.g mid trackable on replies)
             $email->send($this->getEmail(), $msg['subj'], $msg['body'], $attachments,
                 $options);
@@ -1573,7 +1587,9 @@ class Ticket {
                 $recipients[]=$dept->getManager();
 
             $attachments = $note->getAttachments();
-            $options = array('references' => $note->getEmailMessageId());
+            $options = array(
+                'replyto'=>$note->getEmailMessageId(),
+                'references'=>$note->getEmailReferences());
             $sentlist=array();
             foreach( $recipients as $k=>$staff) {
                 if(!is_object($staff)


### PR DESCRIPTION
Previously, the References header emitted by the system for new thread entry auto-responses and alerts included the message-id for which the email was a reply in the `References` header. This patch corrects the issue by
placing the reply message-id in the In-Reply-To header, and constructs a correct References header.

That is, if available, the References header received in the email that was used to create the thread entry is appended to the message-id the email is actually in reply to. This is the expected usage of the References header.
