### PR TITLE
Content disposition parameters are optional

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -370,7 +370,7 @@ class MailFetcher {
         if($part && !$part->parts) {
             //Check if the part is an attachment.
             $filename = false;
-            if ($part->ifdisposition
+            if ($part->ifdisposition && $part->ifdparameters
                     && in_array(strtolower($part->disposition),
                         array('attachment', 'inline'))) {
                 $filename = $this->findFilename($part->dparameters);


### PR DESCRIPTION
If a Content-Disposition header exists for an attachments, it isn't required to have any parameters (like a file name)
