### PR TITLE
Use system date format for datepicker

### DIFF
--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -24,6 +24,7 @@ class ConfigAjaxAPI extends AjaxController {
 
         $config=array(
                       'lock_time'       => ($cfg->getLockTime()*3600),
+                      'date_format'     => ($cfg->getDateFormat()),
                       'max_file_uploads'=> (int) $cfg->getStaffMaxFileUploads()
                       );
         return $this->json_encode($config);

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -287,6 +287,7 @@ class Ticket {
     }
 
     function getUpdateInfo() {
+        global $cfg;
 
         $info=array('name'  =>  $this->getName(),
                     'email' =>  $this->getEmail(),
@@ -297,7 +298,10 @@ class Ticket {
                     'topicId'   =>  $this->getTopicId(),
                     'priorityId'    =>  $this->getPriorityId(),
                     'slaId' =>  $this->getSLAId(),
-                    'duedate'   =>  $this->getDueDate()?(Format::userdate('m/d/Y', Misc::db2gmtime($this->getDueDate()))):'',
+                    'duedate'   =>  $this->getDueDate()
+                        ? Format::userdate($cfg->getDateFormat(),
+                            Misc::db2gmtime($this->getDueDate()))
+                        :'',
                     'time'  =>  $this->getDueDate()?(Format::userdate('G:i', Misc::db2gmtime($this->getDueDate()))):'',
                     );
 

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -278,12 +278,29 @@ $(document).ready(function(){
     }
 
     /* Datepicker */
-    $('.dp').datepicker({
-        numberOfMonths: 2,
-        showButtonPanel: true,
-        buttonImage: './images/cal.png',
-        showOn:'both'
-     });
+    getConfig().then(function(c) {
+        var df = c.date_format||'m/d/Y',
+            translation = {
+                'd':'dd',
+                'j':'d',
+                'z':'o',
+                'm':'mm',
+                'F':'MM',
+                'n':'m',
+                'Y':'yy'
+            };
+        // Change PHP formats to datepicker ones
+        $.each(translation, function(php, jqdp) {
+            df = df.replace(php, jqdp);
+        });
+        $('.dp').datepicker({
+            numberOfMonths: 2,
+            showButtonPanel: true,
+            buttonImage: './images/cal.png',
+            showOn:'both',
+            dateFormat: df,
+         });
+    });
 
     /* NicEdit richtext init */
     var rtes = $('.richtext');


### PR DESCRIPTION
Previously the American date format (m/d/Y) was used exclusively for formatting dates in the datepicker widget. This patch enables the widget to be formatted based on the format set in the admin panel.

Fixes #829
