### PR TITLE
Fix parsing issue in strtotime()

### DIFF
--- a/css/osticket.css
+++ b/css/osticket.css
@@ -23,3 +23,7 @@
 }
 
 #loading h4 { margin: 3px 0 0 0; padding: 0; color: #d80; }
+
+input.dp {
+    width: 10em;
+}

--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -2,6 +2,9 @@
 if(!defined('OSTSCPINC') || !$thisstaff || !$thisstaff->canEditTickets() || !$ticket) die('Access Denied');
 
 $info=Format::htmlchars(($errors && $_POST)?$_POST:$ticket->getUpdateInfo());
+if ($_POST)
+    $info['duedate'] = Format::date($cfg->getDateFormat(),
+       strtotime($info['duedate']));
 ?>
 <form action="tickets.php?id=<?php echo $ticket->getId(); ?>&a=edit" method="post" id="save"  enctype="multipart/form-data">
  <?php csrf_token(); ?>

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -1404,3 +1404,6 @@ ul.progress li.no small {color:red;}
 
 #loading h4, #upgrading h4 { margin: 3px 0 0 0; padding: 0; color: #d80; }
 
+input.dp {
+    width: 10em;
+}

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -299,7 +299,14 @@ $(document).ready(function(){
             buttonImage: './images/cal.png',
             showOn:'both',
             dateFormat: df,
-         });
+        });
+        $(document).on('submit', 'form', function() {
+            $('.dp', $(this)).each(function(i, e) {
+                var $e = $(e),
+                    d = $e.datepicker('getDate');
+                $e.val(d.toJSON().substring(0,10));
+            });
+        });
     });
 
     /* NicEdit richtext init */


### PR DESCRIPTION
PHP can't discern the difference between d/m/Y and m/d/Y when just the date is submitted to `strtotime()`. Unfortunately, `strptime()` is not available until PHP 5.1.0. This patch forces datepickers to change their values to YYYY-MM-DD upon submission to disambiguate parsing issues.

Fixes #832
