### PR TITLE
Fix filter issue where negative logic prevents matches

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -786,6 +786,9 @@ class TicketFilter {
         if($this->vars['subject'])
             $sql.=" OR (what='subject' AND LOCATE(val, ".db_input($this->vars['subject']).'))';
 
+        # Always include negative-logic rules
+        $sql.=" OR how IN ('dn_contain', 'not_equal')";
+
 
         # Also include filters that do not have any rules concerning either
         # sender-email-addresses or sender-names or subjects


### PR DESCRIPTION
The quickList() method will attempt to ask the database to find filters that might match the incoming ticket information. The idea is that MySQL is likely faster than PHP. The problem is that it assumes positive logic is being utilized.

This patch adds all filters with at least one rule with dn_contain (does-not-contain) or not_equal (not-equal)

Fixes #838
