### PR TITLE
email: Accept inline body with disposition params

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -297,7 +297,11 @@ class MailFetcher {
             $struct=@imap_fetchstructure($this->mbox, $mid);
 
         //Match the mime type.
-        if($struct && !$struct->ifdparameters && strcasecmp($mimeType, $this->getMimeType($struct))==0) {
+        if($struct
+                && strcasecmp($mimeType, $this->getMimeType($struct))==0
+                && (!$struct->ifdparameters
+                    || !$this->findFilename($struct->dparameters))) {
+
             $partNumber=$partNumber?$partNumber:1;
             if(($text=imap_fetchbody($this->mbox, $mid, $partNumber))) {
                 if($struct->encoding==3 or $struct->encoding==4) //base64 and qp decode.


### PR DESCRIPTION
A mail client may indicate a header parameter (such as Novell Groupwise, which may add something like

```
Content-Disposition: inline; modification-time: "Thu ..."
```

Previously, the system would not consider the content to be a candidate for the email body, because it has parameters to the content-disposition header.

This patch will still consider the part to be a candidate for the body if the mime types match and no filename is found in the content-disposition parameters.
