### PR TITLE
auth: Handle REQUEST_URI not being authoritative

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -140,7 +140,6 @@
 
     #CURRENT EXECUTING SCRIPT.
     define('THISPAGE', Misc::currentURL());
-    define('THISURI', $_SERVER['REQUEST_URI']);
 
     # This is to support old installations. with no secret salt.
     if(!defined('SECRET_SALT')) define('SECRET_SALT',md5(TABLE_PREFIX.ADMIN_EMAIL));

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -49,7 +49,8 @@ require_once(INCLUDE_DIR.'class.csrf.php');
 if(!function_exists('staffLoginPage')) { //Ajax interface can pre-declare the function to  trap expired sessions.
     function staffLoginPage($msg) {
         global $ost, $cfg;
-        $_SESSION['_staff']['auth']['dest']=THISURI;
+        $_SESSION['_staff']['auth']['dest'] =
+            '/' . ltrim($_SERVER['REQUEST_URI'], '/');
         $_SESSION['_staff']['auth']['msg']=$msg;
         require(SCP_DIR.'login.php');
         exit;


### PR DESCRIPTION
If _SERVER{REQUEST_URI} does not start with a leading slash, add one. This will ensure that the redirect URL offered after a successful login will be to an absolute url rather than an implied relative one.

Fixes osTicket/osTicket-1.7#858
