### PR TITLE
mysqli: Allow specification of a unix socket

### DIFF
--- a/include/mysqli.php
+++ b/include/mysqli.php
@@ -39,18 +39,24 @@ function db_connect($host, $user, $passwd, $options = array()) {
         return NULL;
 
     $port = ini_get("mysqli.default_port");
+    $socket = ini_get("mysqli.default_socket");
     if (strpos($host, ':') !== false) {
-        list($host, $port) = explode(':', $host);
+        list($host, $portspec) = explode(':', $host);
         // PHP may not honor the port number if connecting to 'localhost'
-        if (!strcasecmp($host, 'localhost'))
-            // XXX: Looks like PHP gethostbyname() is IPv4 only
-            $host = gethostbyname($host);
-        $port = (int) $port;
+        if ($portspec && is_numeric($portspec)) {
+            if (!strcasecmp($host, 'localhost'))
+                // XXX: Looks like PHP gethostbyname() is IPv4 only
+                $host = gethostbyname($host);
+            $port = (int) $portspec;
+        }
+        elseif ($portspec) {
+            $socket = $portspec;
+        }
     }
 
     // Connect
     $start = microtime(true);
-    if (!@$__db->real_connect($host, $user, $passwd, null, $port)) # nolint
+    if (!@$__db->real_connect($host, $user, $passwd, null, $port, $socket)) # nolint
         return NULL;
 
     //Select the database, if any.

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -81,9 +81,7 @@ class Installer extends SetupWizard {
 
         // Support port number specified in the hostname with a colon (:)
         list($host, $port) = explode(':', $vars['dbhost']);
-        if ($port && (!is_numeric($port) || !((int)$port)))
-            $this->errors['db'] = 'Database port number must be a number';
-        elseif ($port && ($port < 1 || $port > 65535))
+        if ($port && is_numeric($port) && ($port < 1 || $port > 65535))
             $this->errors['db'] = 'Invalid database port number';
 
         //MYSQL: Connect to the DB and check the version & database (create database if it doesn't exist!)


### PR DESCRIPTION
This patch allows for the specification of a socket in the database hostname field, such as 

```
localhost:/path/to/mysql.sock
```
