### PR TITLE
Fixes FAQ time issue 136

### DIFF
--- a/include/client/faq.inc.php
+++ b/include/client/faq.inc.php
@@ -29,4 +29,4 @@ if($faq->getNumAttachments()) { ?>
 </div>
 </p>
 <hr>
-<div class="faded">&nbsp;Last updated <?php echo Format::db_daydatetime($category->getUpdateDate()); ?></div>
+<div class="faded">&nbsp;Last updated <?php echo Format::db_daydatetime($faq->getUpdateDate()); ?></div>

--- a/include/staff/faq-view.inc.php
+++ b/include/staff/faq-view.inc.php
@@ -32,7 +32,7 @@ if($thisstaff->canManageFAQ()) {
     <?php echo ($topics=$faq->getHelpTopics())?implode(', ',$topics):' '; ?>
     </div>
 </p>
-<div class="faded">&nbsp;Last updated <?php echo Format::db_daydatetime($category->getUpdateDate()); ?></div>
+<div class="faded">&nbsp;Last updated <?php echo Format::db_daydatetime($faq->getUpdateDate()); ?></div>
 <hr>
 <?php
 if($thisstaff->canManageFAQ()) {


### PR DESCRIPTION
Need to run these queries to update the schema, should perhaps be your call how that is done:

```
ALTER TABLE `ost_faq` CHANGE `created` `created` DATETIME NOT NULL 
ALTER TABLE `ost_faq` CHANGE `updated` `updated` DATETIME NOT NULL 
```

Original was trying to display the last update of the category, instead of the faq item. Tested, works.

Refer: https://github.com/osTicket/osTicket-1.8/issues/136
