### PR TITLE
Response to issue 505

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -652,6 +652,10 @@ class OsticketConfig extends Config {
     function autoAssignReopenedTickets() {
         return ($this->get('auto_assign_reopened_tickets'));
     }
+    
+    function autoAssignOnReply(){
+        return ($this->get('auto_assign_on_reply'));
+    }
 
     function showAssignedTickets() {
         return ($this->get('show_assigned_tickets'));
@@ -857,6 +861,7 @@ class OsticketConfig extends Config {
             'enable_captcha'=>isset($vars['enable_captcha'])?1:0,
             'log_ticket_activity'=>isset($vars['log_ticket_activity'])?1:0,
             'auto_assign_reopened_tickets'=>isset($vars['auto_assign_reopened_tickets'])?1:0,
+            'auto_assign_on_reply'=>isset($vars['auto_assign_on_reply'])?1:0,
             'show_assigned_tickets'=>isset($vars['show_assigned_tickets'])?1:0,
             'show_answered_tickets'=>isset($vars['show_answered_tickets'])?1:0,
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1438,6 +1438,9 @@ class Ticket {
 
         if(!$vars['staffId'] && $thisstaff)
             $vars['staffId'] = $thisstaff->getId();
+            
+        if($cfg->autoAssignOnReply() && $this->isOpen() && !$this->isAssigned() && $thisstaff->canAssignTickets())
+            $this->setStaffId($thisstaff->getId()); //Ticket wasn't assigned, staff replying now is assigned.
 
         if(!($response = $this->getThread()->addResponse($vars, $errors)))
             return null;

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -125,6 +125,13 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
+            <td>Assign on Reply to Tickets:</td>
+            <td>
+                <input type="checkbox" name="auto_assign_on_reply" <?php echo $config['auto_assign_on_reply']?'checked="checked"':''; ?>>
+                Auto-assigns ticket to the first staff respondent who is able to claim it.
+            </td>
+        </tr>
+        <tr>
             <td>Assigned Tickets:</td>
             <td>
                 <input type="checkbox" name="show_assigned_tickets" <?php echo $config['show_assigned_tickets']?'checked="checked"':''; ?>>


### PR DESCRIPTION
https://github.com/osTicket/osTicket-1.7/issues/505

This auto-assigns a ticket to the first staff member capable of claiming a ticket who replies to it.

Includes Admin option to enable/disable on normal Ticket settings page.
