### PR TITLE
Add a feature to prevent duplicate POSTs

### DIFF
--- a/client.inc.php
+++ b/client.inc.php
@@ -61,6 +61,8 @@ if ($_POST  && !$ost->checkCSRFToken()) {
     @header('Location: index.php');
     //just incase redirect fails
     die('Action denied (400)!');
+} elseif ($_POST && !$ost->checkActivityToken()) {
+    $errors['err'] = 'Cowardly refusing to repeat previous activity';
 }
 
 /* Client specific defaults */

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -117,6 +117,30 @@ class osTicket {
         return false;
     }
 
+    function checkActivityToken($name='__activity__') {
+        global $thisstaff, $thisclient;
+        $user = null;
+
+        if (defined('OSTSTAFFINC') && $thisstaff) {
+            $user = $thisstaff;
+        }
+        elseif (defined('OSTCLIENTINC') && $thisclient) {
+            $user = $thisclient;
+        }
+        if (isset($_POST[$name]) && $user) {
+            // Ensure the token matches the current token for the user. If
+            // they don't match, this is likely a stale form post
+            $pass = ($user->getActivityToken() == $_POST[$name]);
+            // Regardless, the same token CANNOT be used in a future post
+            $user->rollActivityToken();
+            return $pass;
+        }
+        else {
+            // Token not found. Pass by default
+            return true;
+        }
+    }
+
     function getLinkToken() {
         return md5($this->getCSRFToken().SECRET_SALT.session_id());
     }

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -14,6 +14,7 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):$info;
 <p>Please fill in the form below to open a new ticket.</p>
 <form id="ticketForm" method="post" action="open.php" enctype="multipart/form-data">
   <?php csrf_token(); ?>
+  <?php activity_token(); ?>
   <input type="hidden" name="a" value="open">
   <table width="800" cellpadding="1" cellspacing="0" border="0">
     <tr>

--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -97,6 +97,7 @@ if($ticket->getThreadCount() && ($thread=$ticket->getClientThread())) {
 <?php } ?>
 <form id="reply" action="tickets.php?id=<?php echo $ticket->getExtId(); ?>#reply" name="reply" method="post" enctype="multipart/form-data">
     <?php csrf_token(); ?>
+    <?php activity_token(); ?>
     <h2>Post a Reply</h2>
     <input type="hidden" name="id" value="<?php echo $ticket->getExtId(); ?>">
     <input type="hidden" name="a" value="reply">

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -5,6 +5,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
 ?>
 <form action="tickets.php?a=open" method="post" id="save"  enctype="multipart/form-data">
  <?php csrf_token(); ?>
+ <?php activity_token(); ?>
  <input type="hidden" name="do" value="create">
  <input type="hidden" name="a" value="open">
  <h2>Open New Ticket</h2>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -392,6 +392,7 @@ if(!$cfg->showNotesInline()) { ?>
     if($thisstaff->canPostReply()) { ?>
     <form id="reply" action="tickets.php?id=<?php echo $ticket->getId(); ?>#reply" name="reply" method="post" enctype="multipart/form-data">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="msgId" value="<?php echo $msgId; ?>">
         <input type="hidden" name="a" value="reply">
@@ -516,6 +517,7 @@ if(!$cfg->showNotesInline()) { ?>
     } ?>
     <form id="note" action="tickets.php?id=<?php echo $ticket->getId(); ?>#note" name="note" method="post" enctype="multipart/form-data">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="locktime" value="<?php echo $cfg->getLockTime(); ?>">
         <input type="hidden" name="a" value="postnote">
@@ -622,6 +624,7 @@ if(!$cfg->showNotesInline()) { ?>
     if($thisstaff->canTransferTickets()) { ?>
     <form id="transfer" action="tickets.php?id=<?php echo $ticket->getId(); ?>#transfer" name="transfer" method="post" enctype="multipart/form-data">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="ticket_id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="a" value="transfer">
         <table border="0" cellspacing="0" cellpadding="3">
@@ -680,6 +683,7 @@ if(!$cfg->showNotesInline()) { ?>
     if($thisstaff->canAssignTickets()) { ?>
     <form id="assign" action="tickets.php?id=<?php echo $ticket->getId(); ?>#assign" name="assign" method="post" enctype="multipart/form-data">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="a" value="assign">
         <table border="0" cellspacing="0" cellpadding="3">
@@ -770,6 +774,7 @@ if(!$cfg->showNotesInline()) { ?>
     <hr/>
     <form action="tickets.php?id=<?php echo $ticket->getId(); ?>" method="post" id="print-form" name="print-form">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="a" value="print">
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <fieldset class="notes">
@@ -810,6 +815,7 @@ if(!$cfg->showNotesInline()) { ?>
     <?php echo sprintf('Are you sure you want to <b>%s</b> this ticket?', $ticket->isClosed()?'REOPEN':'CLOSE'); ?>
     <form action="tickets.php?id=<?php echo $ticket->getId(); ?>" method="post" id="status-form" name="status-form">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="a" value="process">
         <input type="hidden" name="do" value="<?php echo $ticket->isClosed()?'reopen':'close'; ?>">
@@ -863,6 +869,7 @@ if(!$cfg->showNotesInline()) { ?>
     <div>Please confirm to continue.</div>
     <form action="tickets.php?id=<?php echo $ticket->getId(); ?>" method="post" id="confirm-form" name="confirm-form">
         <?php csrf_token(); ?>
+        <?php activity_token(); ?>
         <input type="hidden" name="id" value="<?php echo $ticket->getId(); ?>">
         <input type="hidden" name="a" value="process">
         <input type="hidden" name="do" id="action" value="">

--- a/open.php
+++ b/open.php
@@ -16,8 +16,7 @@
 require('client.inc.php');
 define('SOURCE','Web'); //Ticket source.
 $ticket = null;
-$errors=array();
-if($_POST):
+if($_POST && !$errors):
     $vars = $_POST;
     $vars['deptId']=$vars['emailId']=0; //Just Making sure we don't accept crap...only topicId is expected.
     if($thisclient) {

--- a/scp/staff.inc.php
+++ b/scp/staff.inc.php
@@ -121,6 +121,8 @@ if($ost->isUpgradePending() && !$exempt) {
 } elseif($cfg->isHelpDeskOffline()) {
     $sysnotice='<strong>System is set to offline mode</strong> - Client interface is disabled and ONLY admins can access staff control panel.';
     $sysnotice.=' <a href="settings.php">Enable</a>.';
+} elseif ($_POST && !$ost->checkActivityToken()) {
+    $errors['err'] = 'Cowardly refusing to repeat previous activity';
 }
 
 $nav = new StaffNav($thisstaff);

--- a/tickets.php
+++ b/tickets.php
@@ -28,7 +28,7 @@ if($_REQUEST['id']) {
 }
 
 //Process post...depends on $ticket object above.
-if($_POST && is_object($ticket) && $ticket->getId()):
+if($_POST && is_object($ticket) && $ticket->getId() && !$errors):
     $errors=array();
     switch(strtolower($_POST['a'])){
     case 'reply':


### PR DESCRIPTION
This patch adds an activity token to the page (if the `<?php activity_token(); ?>` is added to a PHP template inside of a form with method="post"). When the request is sent to the server, the server will confirm the current activity token in the user's session with the activity token sent in the request. If they match, then the request represents new activity. If they do not match, the request is likely a repeat.

The token is rolled each time it is checked, regardless if the activity token represents new or repeat activity.
