### PR TITLE
Honor ticket number in subject line without brackets

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -728,7 +728,7 @@ Class ThreadEntry {
         $subject = $mailinfo['subject'];
         $match = array();
         if ($subject && $mailinfo['email']
-                && preg_match("/\[#([0-9]{1,10})\]/", $subject, $match)
+                && preg_match("/#[\p{L}-]+?([0-9]{1,10})/u", $subject, $match)
                 && ($tid = Ticket::getIdByExtId((int)$match[1], $mailinfo['email']))
                 )
             // Return last message for the thread


### PR DESCRIPTION
We introduced a glitch in 29b3714, which was the patch that introduced matching on email headers other than the Subject.

I misinterpreted the original `preg_match()` regex, thinking that it was requiring brackets. Looking at it again today, I see that it didn't. The current one does, however, require surrounding brackets.

Fixes osTicket/osTicket-1.8#342
