### PR TITLE
Use case-insensitive matching on email address

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -176,7 +176,7 @@ class Ticket {
 
     function getAuthToken() {
         # XXX: Support variable email address (for CCs)
-        return md5($this->getId() . $this->getEmail() . SECRET_SALT);
+        return md5($this->getId() . strtolower($this->getEmail()) . SECRET_SALT);
     }
 
     function getName() {


### PR DESCRIPTION
This patch addresses an issue where a client may have upper-case letters in their email address. When visiting the client portal to check the ticket status, previously, the exact same case would be required in the 'Email Address' box.

This patch remove the case sensitivity for email logins.

Fixes osTicket/osTicket-1.7#875
